### PR TITLE
feat: add SonarQube Cloud coverage analysis

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -11,35 +11,20 @@ on:
 jobs:
   frontend:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup Node
         uses: actions/setup-node@v4
-
+        with:
+          node-version: 18
       - name: Install & Build
         run: |
           cd frontend
           npm ci
           npm run build
-
-      - name: Run tests (if present)
-        run: |
-          cd frontend
-          npm test --if-present
-
-      # SonarCloud scan (this is what makes branches appear in SonarCloud)
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v2
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.branch.name=${{ github.head_ref || github.ref_name }}
       - name: Run tests with coverage
         run: |
           cd frontend


### PR DESCRIPTION
## Summary
- Added `sonar-project.properties` with project/org keys and coverage report paths for both frontend and backend
- Updated `.github/ci.yml` with 3 jobs: frontend coverage, backend coverage, and SonarQube scan
- Added `lcov` reporter to `frontend/vite.config.ts` so Vitest outputs the required `lcov.info`

## Test plan
- [ ] Verify CI passes (frontend, backend, sonar jobs all green)
- [ ] Check SonarQube Cloud shows coverage data on main branch after merge

## Notes
- Automatic Analysis must be disabled in SonarCloud (Administration > Analysis method) for CI-based analysis to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)