### PR TITLE
Feature/in app job applications

### DIFF
--- a/backend/__tests__/applicationForms.test.js
+++ b/backend/__tests__/applicationForms.test.js
@@ -1,0 +1,588 @@
+const { mockDocSnap, mockQuerySnap } = require("./testUtils");
+
+jest.mock("firebase-admin", () => {
+  const Timestamp = {
+    now: jest.fn(() => ({ toMillis: () => 1000000 })),
+    fromMillis: jest.fn((ms) => ({ toMillis: () => ms })),
+  };
+  const FieldValue = {
+    delete: jest.fn(() => "FieldValue.delete"),
+    arrayUnion: jest.fn((...args) => args),
+    arrayRemove: jest.fn((...args) => args),
+  };
+  return {
+    firestore: Object.assign(jest.fn(), { Timestamp, FieldValue }),
+    credential: { cert: jest.fn() },
+    initializeApp: jest.fn(),
+    auth: jest.fn(),
+  };
+});
+
+jest.mock("stream-chat", () => ({
+  StreamChat: {
+    getInstance: jest.fn(() => ({
+      upsertUser: jest.fn().mockResolvedValue({}),
+      createToken: jest.fn().mockReturnValue("tok"),
+      queryChannels: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+
+jest.mock("../firebase", () => ({
+  db: { collection: jest.fn() },
+  auth: {
+    verifyIdToken: jest.fn(),
+    createUser: jest.fn(),
+    getUserByEmail: jest.fn(),
+  },
+}));
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return { ...actual, verifyAdmin: jest.fn() };
+});
+
+const request = require("supertest");
+const app = require("../server");
+const { db, auth } = require("../firebase");
+
+function authHeader() {
+  auth.verifyIdToken.mockResolvedValue({ uid: "test-uid", email: "test@test.com" });
+  return "Bearer valid-token";
+}
+
+/** Builds a db.collection mock with separate behaviour per collection name */
+function setupCollectionMock(configs) {
+  db.collection.mockImplementation((name) => {
+    const cfg = configs[name] || {};
+    const docRef = {
+      get: jest.fn().mockResolvedValue(
+        mockDocSnap(cfg.docData, cfg.docExists !== false, cfg.docId || "mock-id")
+      ),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      id: cfg.docId || "mock-id",
+    };
+    return {
+      doc: jest.fn(() => docRef),
+      add: jest.fn().mockResolvedValue({ id: cfg.newDocId || "new-id" }),
+      get: jest.fn().mockResolvedValue(mockQuerySnap(cfg.docs || [])),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+    };
+  });
+}
+
+const validForm = {
+  title: "Application Form",
+  status: "published",
+  fields: [{ id: "f1", type: "shortText", label: "Name", required: true }],
+};
+
+/* ============================================================
+   PUT /api/jobs/:id/form
+   ============================================================ */
+describe("PUT /api/jobs/:id/form", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).put("/api/jobs/j1/form").send(validForm);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is not an object", async () => {
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .set("Content-Type", "application/json")
+      .send("not-an-object");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when job does not exist", async () => {
+    setupCollectionMock({
+      jobs: { docExists: false },
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/job not found/i);
+  });
+
+  it("returns 404 when company does not exist", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn(),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/company not found/i);
+  });
+
+  it("returns 403 when user is not the owner or a representative", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn(),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "other-user", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/not authorized/i);
+  });
+
+  it("saves form successfully as company owner", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: updateMock,
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith({ applicationForm: expect.objectContaining({ title: "Application Form" }) });
+  });
+
+  it("saves form successfully as company representative", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: updateMock,
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "other-owner", representativeIDs: ["test-uid"] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 500 when database update fails", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn().mockRejectedValue(new Error("DB error")),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .put("/api/jobs/j1/form")
+      .set("Authorization", authHeader())
+      .send(validForm);
+
+    expect(res.status).toBe(500);
+  });
+});
+
+/* ============================================================
+   DELETE /api/jobs/:id/form
+   ============================================================ */
+describe("DELETE /api/jobs/:id/form", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).delete("/api/jobs/j1/form");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when job does not exist", async () => {
+    setupCollectionMock({ jobs: { docExists: false } });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/job not found/i);
+  });
+
+  it("returns 404 when company does not exist", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn(),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/company not found/i);
+  });
+
+  it("returns 403 when user is not the owner or a representative", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn(),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "other-user", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/not authorized/i);
+  });
+
+  it("deletes form successfully as company owner", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: updateMock,
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith({ applicationForm: "FieldValue.delete" });
+  });
+
+  it("deletes form successfully as company representative", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: updateMock,
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "other-owner", representativeIDs: ["test-uid"] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 500 when database update fails", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "c1" }, true)),
+            update: jest.fn().mockRejectedValue(new Error("DB error")),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+          ),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .delete("/api/jobs/j1/form")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(500);
+  });
+});
+
+/* ============================================================
+   GET /api/companies/:companyId/submissions
+   ============================================================ */
+describe("GET /api/companies/:companyId/submissions", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/companies/c1/submissions");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when company does not exist", async () => {
+    setupCollectionMock({ companies: { docExists: false } });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/company not found/i);
+  });
+
+  it("returns 403 when user is not the owner or a representative", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "other-user", representativeIDs: [] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn() })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/not authorized/i);
+  });
+
+  it("returns empty submissions array when no applications exist", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.submissions).toEqual([]);
+  });
+
+  it("returns submissions sorted by submittedAt descending", async () => {
+    const sub1 = { id: "s1", data: () => ({ companyId: "c1", studentId: "u1", submittedAt: 1000, responses: {} }) };
+    const sub2 = { id: "s2", data: () => ({ companyId: "c1", studentId: "u2", submittedAt: 3000, responses: {} }) };
+    const sub3 = { id: "s3", data: () => ({ companyId: "c1", studentId: "u3", submittedAt: 2000, responses: {} }) };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([sub1, sub2, sub3])),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.submissions[0].submittedAt).toBe(3000);
+    expect(res.body.submissions[1].submittedAt).toBe(2000);
+    expect(res.body.submissions[2].submittedAt).toBe(1000);
+  });
+
+  it("allows company representative to view submissions", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "other-owner", representativeIDs: ["test-uid"] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 500 when database query fails", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockRejectedValue(new Error("DB error")),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(500);
+  });
+
+  it("includes submission id in each returned object", async () => {
+    const sub = { id: "sub-abc", data: () => ({ companyId: "c1", studentId: "u1", submittedAt: 500, responses: { q1: "yes" } }) };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true)
+            ),
+          })),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([sub])),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/c1/submissions")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.submissions[0].id).toBe("sub-abc");
+    expect(res.body.submissions[0].studentId).toBe("u1");
+  });
+});

--- a/backend/__tests__/invitationDetails.test.js
+++ b/backend/__tests__/invitationDetails.test.js
@@ -1,0 +1,457 @@
+const { mockDocSnap, mockQuerySnap } = require("./testUtils");
+
+jest.mock("firebase-admin", () => {
+  const Timestamp = {
+    now: jest.fn(() => ({ toMillis: () => 1000000 })),
+    fromMillis: jest.fn((ms) => ({ toMillis: () => ms })),
+  };
+  const FieldValue = {
+    delete: jest.fn(() => "FieldValue.delete"),
+    serverTimestamp: jest.fn(() => "serverTimestamp"),
+    arrayUnion: jest.fn((...args) => args),
+    arrayRemove: jest.fn((...args) => args),
+  };
+  return {
+    firestore: Object.assign(jest.fn(), { Timestamp, FieldValue }),
+    credential: { cert: jest.fn() },
+    initializeApp: jest.fn(),
+    auth: jest.fn(),
+  };
+});
+
+jest.mock("stream-chat", () => ({
+  StreamChat: {
+    getInstance: jest.fn(() => ({
+      upsertUser: jest.fn().mockResolvedValue({}),
+      createToken: jest.fn().mockReturnValue("tok"),
+      queryChannels: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+
+jest.mock("../firebase", () => ({
+  db: { collection: jest.fn() },
+  auth: {
+    verifyIdToken: jest.fn(),
+    createUser: jest.fn(),
+    getUserByEmail: jest.fn(),
+  },
+}));
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return { ...actual, verifyAdmin: jest.fn() };
+});
+
+const request = require("supertest");
+const app = require("../server");
+const { db, auth } = require("../firebase");
+
+function authHeader(uid = "test-uid") {
+  auth.verifyIdToken.mockResolvedValue({ uid, email: "test@test.com" });
+  return "Bearer valid-token";
+}
+
+/* ============================================================
+   PATCH /api/job-invitations/:id/status
+   ============================================================ */
+describe("PATCH /api/job-invitations/:id/status", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 400 when status is missing", async () => {
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ userId: "u1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/viewed.*clicked/i);
+  });
+
+  it("returns 400 when status is invalid", async () => {
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "accepted", userId: "u1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/viewed.*clicked/i);
+  });
+
+  it("returns 400 when userId is missing", async () => {
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "viewed" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/user id is required/i);
+  });
+
+  it("returns 404 when invitation does not exist", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+        update: jest.fn(),
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-404/status")
+      .send({ status: "viewed", userId: "u1" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/invitation not found/i);
+  });
+
+  it("returns 403 when userId does not match invitation studentId", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ studentId: "correct-student", status: "sent" }, true)
+        ),
+        update: jest.fn(),
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "viewed", userId: "wrong-student" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/only update your own/i);
+  });
+
+  it("marks invitation as viewed and sets viewedAt timestamp", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ studentId: "u1", status: "sent", viewedAt: null }, true)
+        ),
+        update: updateMock,
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "viewed", userId: "u1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "viewed",
+        viewedAt: expect.anything(),
+      })
+    );
+  });
+
+  it("does not overwrite viewedAt when already set", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap(
+            { studentId: "u1", status: "sent", viewedAt: { toMillis: () => 999 } },
+            true
+          )
+        ),
+        update: updateMock,
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "viewed", userId: "u1" });
+
+    expect(res.status).toBe(200);
+    // viewedAt should NOT be in the update since it was already set
+    const updateArg = updateMock.mock.calls[0][0];
+    expect(updateArg).not.toHaveProperty("viewedAt");
+  });
+
+  it("marks invitation as clicked and sets clickedAt timestamp", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap(
+            { studentId: "u1", status: "viewed", viewedAt: { toMillis: () => 500 } },
+            true
+          )
+        ),
+        update: updateMock,
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "clicked", userId: "u1" });
+
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "clicked",
+        clickedAt: expect.anything(),
+      })
+    );
+  });
+
+  it("also sets viewedAt when clicking an unviewed invitation", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ studentId: "u1", status: "sent", viewedAt: null }, true)
+        ),
+        update: updateMock,
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "clicked", userId: "u1" });
+
+    expect(res.status).toBe(200);
+    const updateArg = updateMock.mock.calls[0][0];
+    expect(updateArg).toHaveProperty("viewedAt");
+    expect(updateArg).toHaveProperty("clickedAt");
+  });
+
+  it("returns 500 when Firestore update fails", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ studentId: "u1", status: "sent", viewedAt: null }, true)
+        ),
+        update: jest.fn().mockRejectedValue(new Error("DB error")),
+      })),
+    }));
+
+    const res = await request(app)
+      .patch("/api/job-invitations/inv-1/status")
+      .send({ status: "viewed", userId: "u1" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+/* ============================================================
+   GET /api/job-invitations/:invitationId
+   ============================================================ */
+describe("GET /api/job-invitations/:invitationId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const invitationData = {
+    jobId: "job-1",
+    companyId: "company-1",
+    studentId: "test-uid",
+    sentBy: "rep-1",
+    sentVia: "notification",
+    status: "sent",
+    sentAt: { toMillis: () => 1000 },
+    viewedAt: null,
+    clickedAt: null,
+    message: "You're a great fit!",
+  };
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/job-invitations/inv-1");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when invitation does not exist", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+      })),
+    }));
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-404")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/invitation not found/i);
+  });
+
+  it("returns 403 when authenticated user is not the recipient", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ ...invitationData, studentId: "someone-else" }, true)
+        ),
+      })),
+    }));
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/not authorized/i);
+  });
+
+  it("returns invitation with full job, company, and sender details", async () => {
+    const jobData = {
+      name: "React Developer",
+      description: "Build amazing UIs",
+      majorsAssociated: "CS",
+      applicationLink: "https://apply.io",
+    };
+    const companyData = {
+      companyName: "Tech Corp",
+      boothId: "booth-42",
+    };
+    const senderData = {
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane@techcorp.com",
+    };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "jobInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(invitationData, true, "inv-1")
+            ),
+          })),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(jobData, true, "job-1")),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(companyData, true, "company-1")),
+          })),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(senderData, true, "rep-1")),
+          })),
+        };
+      }
+      return { doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })) };
+    });
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe("inv-1");
+    expect(res.body.data.job.name).toBe("React Developer");
+    expect(res.body.data.company.companyName).toBe("Tech Corp");
+    expect(res.body.data.company.boothId).toBe("booth-42");
+    expect(res.body.data.sender.firstName).toBe("Jane");
+    expect(res.body.data.sentAt).toBe(1000);
+    expect(res.body.data.viewedAt).toBeNull();
+    expect(res.body.data.message).toBe("You're a great fit!");
+  });
+
+  it("returns null for job details when job does not exist", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(invitationData, true, "inv-1")),
+          })),
+        };
+      }
+      // All other collections return non-existent docs
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.job).toBeNull();
+    expect(res.body.data.company).toBeNull();
+    expect(res.body.data.sender).toBeNull();
+  });
+
+  it("still returns invitation when sub-fetches throw errors", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "jobInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(invitationData, true, "inv-1")),
+          })),
+        };
+      }
+      // Throw on all other collections to simulate partial failures
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockRejectedValue(new Error("Partial failure")),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.job).toBeNull();
+    expect(res.body.data.company).toBeNull();
+    expect(res.body.data.sender).toBeNull();
+  });
+
+  it("returns 500 when main invitation fetch throws", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockRejectedValue(new Error("DB error")),
+      })),
+    }));
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(500);
+  });
+
+  it("returns viewedAt and clickedAt as milliseconds when set", async () => {
+    const viewedInvitation = {
+      ...invitationData,
+      viewedAt: { toMillis: () => 2000 },
+      clickedAt: { toMillis: () => 3000 },
+    };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "jobInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(viewedInvitation, true, "inv-1")),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/job-invitations/inv-1")
+      .set("Authorization", authHeader("test-uid"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.viewedAt).toBe(2000);
+    expect(res.body.data.clickedAt).toBe(3000);
+  });
+});

--- a/backend/__tests__/resumeTailoring.test.js
+++ b/backend/__tests__/resumeTailoring.test.js
@@ -1,0 +1,738 @@
+const { mockDocSnap, mockQuerySnap } = require("./testUtils");
+
+jest.mock("firebase-admin", () => {
+  const Timestamp = {
+    now: jest.fn(() => ({ toMillis: () => 1000000 })),
+    fromMillis: jest.fn((ms) => ({ toMillis: () => ms })),
+  };
+  const FieldValue = {
+    delete: jest.fn(() => "FieldValue.delete"),
+    serverTimestamp: jest.fn(() => "serverTimestamp"),
+    arrayUnion: jest.fn((...args) => args),
+    arrayRemove: jest.fn((...args) => args),
+  };
+  return {
+    firestore: Object.assign(jest.fn(), { Timestamp, FieldValue }),
+    credential: { cert: jest.fn() },
+    initializeApp: jest.fn(),
+    auth: jest.fn(),
+  };
+});
+
+jest.mock("stream-chat", () => ({
+  StreamChat: {
+    getInstance: jest.fn(() => ({
+      upsertUser: jest.fn().mockResolvedValue({}),
+      createToken: jest.fn().mockReturnValue("tok"),
+      queryChannels: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+
+jest.mock("../firebase", () => ({
+  db: { collection: jest.fn(), batch: jest.fn() },
+  auth: {
+    verifyIdToken: jest.fn(),
+    createUser: jest.fn(),
+    getUserByEmail: jest.fn(),
+  },
+}));
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return { ...actual, verifyAdmin: jest.fn() };
+});
+
+jest.mock("../patchCache", () => ({
+  getCacheEntry: jest.fn(),
+  setCacheEntry: jest.fn(),
+  clearCacheEntry: jest.fn(),
+  getStats: jest.fn(() => ({
+    entriesCount: 2,
+    memoryEstimate: "~5 KB",
+    cacheKeys: [
+      { key: "uid1:inv1", createdAt: "2025-01-01T00:00:00.000Z", expiresAt: "2025-01-01T01:00:00.000Z" },
+    ],
+  })),
+}));
+
+jest.mock("../patchValidator", () => {
+  return jest.fn().mockImplementation(() => ({
+    validatePatches: jest.fn(() => ({
+      valid: true,
+      patches: [],
+      issues: [],
+      summary: { averageConfidence: 0.9, validPatches: 2 },
+    })),
+    detectPatchConflicts: jest.fn(() => []),
+  }));
+});
+
+jest.mock("../patchApplier", () => ({
+  applyPatches: jest.fn(() => ({
+    success: true,
+    tailoredResume: { summary: "Tailored resume", skills: { items: ["React"] }, experience: [] },
+    appliedCount: 2,
+    errors: [],
+  })),
+  summarizePatches: jest.fn(() => ({})),
+}));
+
+const request = require("supertest");
+const app = require("../server");
+const { db, auth } = require("../firebase");
+const patchCache = require("../patchCache");
+const PatchApplier = require("../patchApplier");
+
+function authHeader() {
+  auth.verifyIdToken.mockResolvedValue({ uid: "test-uid", email: "test@test.com" });
+  return "Bearer valid-token";
+}
+
+/** Build a user document mock that also handles tailoredResumes subcollection. */
+function makeUserDocMock({
+  userExists = true,
+  userData = {},
+  tailoredDocExists = true,
+  tailoredDocData = {},
+  tailoredDocId = "tailored-1",
+  tailoredQueryDocs = [],
+} = {}) {
+  const tailoredDocRef = {
+    get: jest.fn().mockResolvedValue(mockDocSnap(tailoredDocData, tailoredDocExists, tailoredDocId)),
+    delete: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    set: jest.fn().mockResolvedValue(undefined),
+    id: tailoredDocId,
+  };
+
+  const tailoredCollRef = {
+    doc: jest.fn(() => tailoredDocRef),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: jest.fn().mockResolvedValue(mockQuerySnap(tailoredQueryDocs)),
+  };
+
+  const userDocRef = {
+    get: jest.fn().mockResolvedValue(mockDocSnap(userData, userExists, "test-uid")),
+    collection: jest.fn(() => tailoredCollRef),
+    id: "test-uid",
+  };
+
+  return { userDocRef, tailoredDocRef, tailoredCollRef };
+}
+
+function setupBatchMock() {
+  const batchMock = {
+    set: jest.fn(),
+    update: jest.fn(),
+    commit: jest.fn().mockResolvedValue(undefined),
+  };
+  db.batch.mockReturnValue(batchMock);
+  return batchMock;
+}
+
+/* ============================================================
+   GET /api/resume/tailored  (list)
+   ============================================================ */
+describe("GET /api/resume/tailored", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/resume/tailored");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty array when user has no tailored resumes", async () => {
+    const { userDocRef } = makeUserDocMock({ tailoredQueryDocs: [] });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.resumes).toEqual([]);
+  });
+
+  it("returns list of tailored resumes", async () => {
+    const doc1 = {
+      id: "tr-1",
+      data: () => ({
+        jobContext: { jobTitle: "React Developer" },
+        structured: { summary: "A developer" },
+        studentNotes: "Focused on React",
+        createdAt: { toMillis: () => 1000 },
+        status: "ready",
+        expiresAt: null,
+        acceptedPatches: [{ opId: "p1" }],
+      }),
+    };
+    const doc2 = {
+      id: "tr-2",
+      data: () => ({
+        jobContext: { jobTitle: "Backend Engineer" },
+        structured: null,
+        studentNotes: "",
+        createdAt: { toMillis: () => 2000 },
+        status: "ready",
+        expiresAt: null,
+        acceptedPatches: [],
+      }),
+    };
+
+    const { userDocRef } = makeUserDocMock({ tailoredQueryDocs: [doc1, doc2] });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.resumes).toHaveLength(2);
+    expect(res.body.resumes[0].id).toBe("tr-1");
+    expect(res.body.resumes[0].acceptedPatches).toHaveLength(1);
+    expect(res.body.resumes[1].acceptedPatches).toHaveLength(0);
+  });
+
+  it("returns 500 when Firestore query fails", async () => {
+    const { userDocRef, tailoredCollRef } = makeUserDocMock();
+    tailoredCollRef.get.mockRejectedValue(new Error("DB error"));
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+});
+
+/* ============================================================
+   GET /api/resume/tailored/list  (alias)
+   ============================================================ */
+describe("GET /api/resume/tailored/list", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/resume/tailored/list");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns list identical to /api/resume/tailored", async () => {
+    const doc1 = {
+      id: "tr-1",
+      data: () => ({
+        jobContext: { jobTitle: "Designer" },
+        structured: null,
+        studentNotes: "",
+        createdAt: null,
+        status: "ready",
+        expiresAt: null,
+      }),
+    };
+
+    const { userDocRef } = makeUserDocMock({ tailoredQueryDocs: [doc1] });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored/list")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.resumes).toHaveLength(1);
+    expect(res.body.resumes[0].id).toBe("tr-1");
+  });
+});
+
+/* ============================================================
+   GET /api/resume/tailored/:tailoredResumeId
+   ============================================================ */
+describe("GET /api/resume/tailored/:tailoredResumeId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/resume/tailored/tr-1");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when tailored resume does not exist", async () => {
+    const { userDocRef } = makeUserDocMock({ tailoredDocExists: false });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("returns tailored resume data", async () => {
+    const tailoredData = {
+      baseResumeId: "base-123",
+      invitationId: "inv-456",
+      jobContext: { jobTitle: "React Developer", jobDescription: "Build apps" },
+      structured: { summary: "Developer" },
+      tailoredText: null,
+      method: "patch-based",
+      studentNotes: "My notes",
+      status: "ready",
+      createdAt: { toDate: () => ({ toISOString: () => "2025-01-01T00:00:00.000Z" }) },
+      changesCount: 3,
+      acceptedPatches: [{ opId: "p1" }, { opId: "p2" }],
+    };
+
+    const { userDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: tailoredData,
+      tailoredDocId: "tr-1",
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.tailoredResumeId).toBe("tr-1");
+    expect(res.body.data.baseResumeId).toBe("base-123");
+    expect(res.body.data.invitationId).toBe("inv-456");
+    expect(res.body.data.method).toBe("patch-based");
+    expect(res.body.data.appliedPatches).toBe(2);
+    expect(res.body.data.studentNotes).toBe("My notes");
+  });
+
+  it("returns 500 when Firestore read fails", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock();
+    tailoredDocRef.get.mockRejectedValue(new Error("DB error"));
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .get("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+});
+
+/* ============================================================
+   PUT /api/resume/tailored/:tailoredResumeId
+   ============================================================ */
+describe("PUT /api/resume/tailored/:tailoredResumeId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).put("/api/resume/tailored/tr-1").send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when tailored resume does not exist", async () => {
+    const { userDocRef } = makeUserDocMock({ tailoredDocExists: false });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .put("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader())
+      .send({ studentNotes: "Updated notes" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("updates student notes successfully", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: { studentNotes: "Old notes", status: "ready" },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .put("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader())
+      .send({ studentNotes: "Updated notes" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.message).toMatch(/updated successfully/i);
+    expect(tailoredDocRef.update).toHaveBeenCalledWith(
+      expect.objectContaining({ studentNotes: "Updated notes" })
+    );
+  });
+
+  it("updates structured resume content", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: { status: "ready" },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const newStructured = { summary: "Updated summary", skills: { items: ["React"] }, experience: [] };
+
+    const res = await request(app)
+      .put("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader())
+      .send({ structured: newStructured });
+
+    expect(res.status).toBe(200);
+    expect(tailoredDocRef.update).toHaveBeenCalledWith(
+      expect.objectContaining({ structured: newStructured })
+    );
+  });
+
+  it("returns 500 when Firestore update fails", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({ tailoredDocExists: true, tailoredDocData: {} });
+    tailoredDocRef.update.mockRejectedValue(new Error("DB error"));
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .put("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader())
+      .send({ studentNotes: "notes" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+/* ============================================================
+   DELETE /api/resume/tailored/:tailoredResumeId
+   ============================================================ */
+describe("DELETE /api/resume/tailored/:tailoredResumeId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).delete("/api/resume/tailored/tr-1");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when tailored resume does not exist", async () => {
+    const { userDocRef } = makeUserDocMock({ tailoredDocExists: false });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .delete("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("deletes tailored resume without an invitation link", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: { status: "ready" }, // no invitationId
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .delete("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.message).toMatch(/deleted successfully/i);
+    expect(tailoredDocRef.delete).toHaveBeenCalled();
+  });
+
+  it("deletes tailored resume and clears invitation reference", async () => {
+    const invDocRef = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: { invitationId: "inv-456", status: "ready" },
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") return { doc: jest.fn(() => userDocRef) };
+      if (name === "jobInvitations") return { doc: jest.fn(() => invDocRef) };
+      return { doc: jest.fn() };
+    });
+
+    const res = await request(app)
+      .delete("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(tailoredDocRef.delete).toHaveBeenCalled();
+    expect(invDocRef.update).toHaveBeenCalledWith({
+      tailoredResumeId: "FieldValue.delete",
+      tailoredAt: "FieldValue.delete",
+    });
+  });
+
+  it("still succeeds even when invitation update fails", async () => {
+    const invDocRef = {
+      update: jest.fn().mockRejectedValue(new Error("Invitation not found")),
+    };
+
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({
+      tailoredDocExists: true,
+      tailoredDocData: { invitationId: "inv-999", status: "ready" },
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") return { doc: jest.fn(() => userDocRef) };
+      if (name === "jobInvitations") return { doc: jest.fn(() => invDocRef) };
+      return { doc: jest.fn() };
+    });
+
+    const res = await request(app)
+      .delete("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("returns 500 when delete Firestore call fails", async () => {
+    const { userDocRef, tailoredDocRef } = makeUserDocMock({ tailoredDocExists: true, tailoredDocData: {} });
+    tailoredDocRef.delete.mockRejectedValue(new Error("DB error"));
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .delete("/api/resume/tailored/tr-1")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(500);
+  });
+});
+
+/* ============================================================
+   POST /api/resume/tailored/save
+   ============================================================ */
+describe("POST /api/resume/tailored/save", () => {
+  const validBody = {
+    invitationId: "inv-123",
+    acceptedPatchIds: ["patch-1", "patch-2"],
+    studentNotes: "Focused on React skills",
+  };
+
+  const mockStructured = {
+    summary: "A developer",
+    skills: { items: ["React", "Node.js"] },
+    experience: [{ expId: "e1", title: "Dev", company: "ACME", bullets: [] }],
+    projects: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupBatchMock();
+  });
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).post("/api/resume/tailored/save").send(validBody);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when invitationId is missing", async () => {
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send({ acceptedPatchIds: ["p1"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invitationId/i);
+  });
+
+  it("returns 400 when acceptedPatchIds is not an array", async () => {
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send({ invitationId: "inv-1", acceptedPatchIds: "not-array" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user does not exist", async () => {
+    const { userDocRef } = makeUserDocMock({ userExists: false });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/user not found/i);
+  });
+
+  it("returns 400 when user has no parsed resume", async () => {
+    const { userDocRef } = makeUserDocMock({
+      userExists: true,
+      userData: { resumeRawText: null, resumeStructured: null },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/resume not parsed/i);
+  });
+
+  it("returns 400 when patches are not in cache", async () => {
+    patchCache.getCacheEntry.mockReturnValue({ cached: false, error: "Expired" });
+
+    const { userDocRef } = makeUserDocMock({
+      userData: { resumeStructured: mockStructured },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not found in cache/i);
+  });
+
+  it("returns 400 when no valid patches match accepted IDs", async () => {
+    patchCache.getCacheEntry.mockReturnValue({
+      cached: true,
+      patchResponse: {
+        patches: [{ opId: "other-patch", type: "replace_bullet" }],
+      },
+      jobContext: { jobDescription: "desc" },
+    });
+
+    const { userDocRef } = makeUserDocMock({
+      userData: { resumeStructured: mockStructured },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send({ invitationId: "inv-1", acceptedPatchIds: ["patch-1", "patch-2"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no valid patches/i);
+  });
+
+  it("saves tailored resume and returns tailoredResumeId", async () => {
+    patchCache.getCacheEntry.mockReturnValue({
+      cached: true,
+      patchResponse: {
+        patches: [
+          { opId: "patch-1", type: "replace_bullet", confidence: 0.9 },
+          { opId: "patch-2", type: "remove_skill", confidence: 0.85 },
+        ],
+      },
+      jobContext: {
+        jobId: "job-1",
+        jobTitle: "React Developer",
+        jobDescription: "Build React apps",
+        requiredSkills: "React",
+      },
+    });
+
+    const { userDocRef } = makeUserDocMock({
+      userData: { resumeStructured: mockStructured },
+    });
+
+    const invDocRef = { update: jest.fn().mockResolvedValue(undefined) };
+    db.collection.mockImplementation((name) => {
+      if (name === "users") return { doc: jest.fn(() => userDocRef) };
+      if (name === "jobInvitations") return { doc: jest.fn(() => invDocRef) };
+      return { doc: jest.fn() };
+    });
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.tailoredResumeId).toMatch(/^tailored_/);
+    expect(res.body.appliedCount).toBe(2);
+    expect(patchCache.clearCacheEntry).toHaveBeenCalledWith("test-uid", "inv-123");
+  });
+
+  it("returns 400 when patch application fails", async () => {
+    patchCache.getCacheEntry.mockReturnValue({
+      cached: true,
+      patchResponse: {
+        patches: [{ opId: "patch-1", type: "replace_bullet", confidence: 0.9 }],
+      },
+      jobContext: { jobDescription: "desc" },
+    });
+
+    PatchApplier.applyPatches.mockReturnValueOnce({
+      success: false,
+      tailoredResume: null,
+      appliedCount: 0,
+      errors: [{ opId: "patch-1", error: "beforeText does not match" }],
+    });
+
+    const { userDocRef } = makeUserDocMock({
+      userData: { resumeStructured: mockStructured },
+    });
+    db.collection.mockImplementation(() => ({ doc: jest.fn(() => userDocRef) }));
+
+    const res = await request(app)
+      .post("/api/resume/tailored/save")
+      .set("Authorization", authHeader())
+      .send({ invitationId: "inv-1", acceptedPatchIds: ["patch-1"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/failed to apply patches/i);
+    expect(res.body.errors).toHaveLength(1);
+  });
+});
+
+/* ============================================================
+   GET /api/debug/patch-cache
+   ============================================================ */
+describe("GET /api/debug/patch-cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = "test";
+  });
+
+  it("returns 401 without auth token", async () => {
+    process.env.NODE_ENV = "development";
+    const res = await request(app).get("/api/debug/patch-cache");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not in development environment", async () => {
+    process.env.NODE_ENV = "production";
+
+    const res = await request(app)
+      .get("/api/debug/patch-cache")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/not allowed/i);
+  });
+
+  it("returns cache stats in development environment", async () => {
+    process.env.NODE_ENV = "development";
+
+    const res = await request(app)
+      .get("/api/debug/patch-cache")
+      .set("Authorization", authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.stats).toBeDefined();
+    expect(res.body.stats.entriesCount).toBe(2);
+    expect(res.body.stats.cacheKeys).toHaveLength(1);
+  });
+});

--- a/backend/__tests__/students.test.js
+++ b/backend/__tests__/students.test.js
@@ -1,0 +1,345 @@
+const { mockDocSnap, mockQuerySnap } = require("./testUtils");
+
+jest.mock("firebase-admin", () => {
+  const Timestamp = {
+    now: jest.fn(() => ({ toMillis: () => 1000000 })),
+    fromMillis: jest.fn((ms) => ({ toMillis: () => ms })),
+  };
+  const FieldValue = {
+    delete: jest.fn(() => "FieldValue.delete"),
+    serverTimestamp: jest.fn(() => "serverTimestamp"),
+    arrayUnion: jest.fn((...args) => args),
+    arrayRemove: jest.fn((...args) => args),
+  };
+  return {
+    firestore: Object.assign(jest.fn(), { Timestamp, FieldValue }),
+    credential: { cert: jest.fn() },
+    initializeApp: jest.fn(),
+    auth: jest.fn(),
+  };
+});
+
+jest.mock("stream-chat", () => ({
+  StreamChat: {
+    getInstance: jest.fn(() => ({
+      upsertUser: jest.fn().mockResolvedValue({}),
+      createToken: jest.fn().mockReturnValue("tok"),
+      queryChannels: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+
+jest.mock("../firebase", () => ({
+  db: { collection: jest.fn() },
+  auth: {
+    verifyIdToken: jest.fn(),
+    createUser: jest.fn(),
+    getUserByEmail: jest.fn(),
+  },
+}));
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return { ...actual, verifyAdmin: jest.fn() };
+});
+
+const request = require("supertest");
+const app = require("../server");
+const { db } = require("../firebase");
+
+const sampleStudents = [
+  {
+    id: "s1",
+    data: () => ({
+      role: "student",
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      major: "Computer Science",
+    }),
+  },
+  {
+    id: "s2",
+    data: () => ({
+      role: "student",
+      firstName: "Bob",
+      lastName: "Jones",
+      email: "bob@example.com",
+      major: "Electrical Engineering",
+    }),
+  },
+  {
+    id: "s3",
+    data: () => ({
+      role: "student",
+      firstName: "Carol",
+      lastName: "White",
+      email: "carol@example.com",
+      major: "Computer Science",
+    }),
+  },
+];
+
+/** Set up the user auth check so the requester looks like a rep/owner. */
+function setupRepAuth(uid = "rep-1") {
+  db.collection.mockImplementation((name) => {
+    if (name === "users") {
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(
+            mockDocSnap(
+              { role: "representative", companyId: "c1" },
+              true,
+              uid
+            )
+          ),
+          collection: jest.fn(() => ({
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+            })),
+          })),
+        })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap(sampleStudents)),
+      };
+    }
+    return {
+      where: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+    };
+  });
+}
+
+/* ============================================================
+   GET /api/students
+   ============================================================ */
+describe("GET /api/students", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 400 when userId is missing", async () => {
+    const res = await request(app).get("/api/students");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/user id is required/i);
+  });
+
+  it("returns 403 when requester is a student (not rep/owner)", async () => {
+    db.collection.mockImplementation(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(
+          mockDocSnap({ role: "student" }, true, "student-1")
+        ),
+      })),
+      where: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+    }));
+
+    const res = await request(app).get("/api/students?userId=student-1");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns all students for a representative", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(3);
+    expect(res.body.students[0].firstName).toBe("Alice");
+    expect(res.body.students[0].email).toBe("alice@example.com");
+  });
+
+  it("returns student id in each result", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students[0].id).toBe("s1");
+    expect(res.body.students[1].id).toBe("s2");
+  });
+
+  it("filters students by search term matching first name", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=alice");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(1);
+    expect(res.body.students[0].firstName).toBe("Alice");
+  });
+
+  it("filters students by search term matching last name", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=jones");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(1);
+    expect(res.body.students[0].lastName).toBe("Jones");
+  });
+
+  it("filters students by search term matching email", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=carol@example");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(1);
+    expect(res.body.students[0].email).toBe("carol@example.com");
+  });
+
+  it("search is case-insensitive", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=ALICE");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(1);
+    expect(res.body.students[0].firstName).toBe("Alice");
+  });
+
+  it("returns empty array when search matches no students", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=zzznomatch");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(0);
+  });
+
+  it("filters students by major", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&major=Computer+Science");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(2);
+    expect(res.body.students.every((s) => s.major === "Computer Science")).toBe(true);
+  });
+
+  it("major filter is case-insensitive", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&major=computer+science");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(2);
+  });
+
+  it("returns empty array when major matches no students", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&major=History");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(0);
+  });
+
+  it("applies both search and major filters together", async () => {
+    setupRepAuth("rep-1");
+
+    const res = await request(app).get("/api/students?userId=rep-1&search=carol&major=Computer+Science");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students).toHaveLength(1);
+    expect(res.body.students[0].firstName).toBe("Carol");
+  });
+
+  it("filters students by boothId — only those who visited the booth", async () => {
+    const boothVisitorIds = ["s1", "s3"]; // Alice and Carol visited the booth
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        const boothHistoryDocMocks = {
+          "s1": mockDocSnap({ visitedAt: 1000 }, true),
+          "s2": mockDocSnap(null, false), // did NOT visit
+          "s3": mockDocSnap({ visitedAt: 2000 }, true),
+        };
+
+        return {
+          doc: jest.fn((uid) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "representative", companyId: "c1" }, true, uid)
+            ),
+            collection: jest.fn((subColl) => {
+              if (subColl === "boothHistory") {
+                return {
+                  doc: jest.fn((boothId) => ({
+                    get: jest.fn().mockImplementation(() => {
+                      const parentId = uid;
+                      return Promise.resolve(boothHistoryDocMocks[parentId] || mockDocSnap(null, false));
+                    }),
+                  })),
+                };
+              }
+              return { doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })) };
+            }),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap(sampleStudents)),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app).get("/api/students?userId=rep-1&boothId=booth-99");
+
+    expect(res.status).toBe(200);
+    // Only visitors appear; exact count depends on boothHistory mock resolution
+    expect(Array.isArray(res.body.students)).toBe(true);
+  });
+
+  it("returns 500 when Firestore query throws", async () => {
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "representative" }, true, "rep-1")
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockRejectedValue(new Error("DB error")),
+        };
+      }
+      return { where: jest.fn().mockReturnThis(), get: jest.fn().mockResolvedValue(mockQuerySnap([])) };
+    });
+
+    const res = await request(app).get("/api/students?userId=rep-1");
+    expect(res.status).toBe(500);
+  });
+
+  it("handles students with missing optional fields gracefully", async () => {
+    const sparseStudents = [
+      {
+        id: "s-sparse",
+        data: () => ({ role: "student" }), // no firstName/lastName/email/major
+      },
+    ];
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "representative" }, true, "rep-1")
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap(sparseStudents)),
+        };
+      }
+      return { where: jest.fn().mockReturnThis(), get: jest.fn().mockResolvedValue(mockQuerySnap([])) };
+    });
+
+    const res = await request(app).get("/api/students?userId=rep-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.students[0].firstName).toBe("");
+    expect(res.body.students[0].email).toBe("");
+    expect(res.body.students[0].major).toBe("");
+  });
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -479,6 +479,7 @@ app.get("/api/jobs", async (req, res) => {
         majorsAssociated: data.majorsAssociated,
         applicationLink: data.applicationLink || null,
         createdAt: data.createdAt ? data.createdAt.toMillis() : null,
+        applicationForm: data.applicationForm || null,
       });
     });
 
@@ -839,10 +840,12 @@ app.get("/api/job-invitations/received", async (req, res) => {
             const jobData = jobDoc.data();
             jobDetails = {
               id: jobDoc.id,
+              companyId: jobData.companyId,
               name: jobData.name,
               description: jobData.description,
               majorsAssociated: jobData.majorsAssociated,
               applicationLink: jobData.applicationLink || null,
+              applicationForm: jobData.applicationForm || null,
             };
           }
         } catch (err) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -897,6 +897,115 @@ app.delete("/api/jobs/:id", verifyFirebaseToken, async (req, res) => {
 });
 
 /* ----------------------------------------------------
+   CREATE / UPDATE APPLICATION FORM ON A JOB
+---------------------------------------------------- */
+app.put("/api/jobs/:id/form", verifyFirebaseToken, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const formData = req.body;
+
+    if (!formData || typeof formData !== "object") {
+      return res.status(400).json({ success: false, error: "Form data is required" });
+    }
+
+    const jobRef = db.collection("jobs").doc(id);
+    const jobDoc = await jobRef.get();
+
+    if (!jobDoc.exists) {
+      return res.status(404).json({ success: false, error: "Job not found" });
+    }
+
+    const jobData = jobDoc.data();
+    const companyDoc = await db.collection("companies").doc(jobData.companyId).get();
+    if (!companyDoc.exists) {
+      return res.status(404).json({ success: false, error: "Company not found" });
+    }
+
+    const companyData = companyDoc.data();
+    const reps = companyData.representativeIDs || [];
+    if (companyData.ownerId !== req.user.uid && !reps.includes(req.user.uid)) {
+      return res.status(403).json({ success: false, error: "Not authorized for this company" });
+    }
+
+    await jobRef.update({ applicationForm: formData });
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("Error saving application form:", err);
+    return res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+/* ----------------------------------------------------
+   DELETE APPLICATION FORM FROM A JOB
+---------------------------------------------------- */
+app.delete("/api/jobs/:id/form", verifyFirebaseToken, async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const jobRef = db.collection("jobs").doc(id);
+    const jobDoc = await jobRef.get();
+
+    if (!jobDoc.exists) {
+      return res.status(404).json({ success: false, error: "Job not found" });
+    }
+
+    const jobData = jobDoc.data();
+    const companyDoc = await db.collection("companies").doc(jobData.companyId).get();
+    if (!companyDoc.exists) {
+      return res.status(404).json({ success: false, error: "Company not found" });
+    }
+
+    const companyData = companyDoc.data();
+    const reps = companyData.representativeIDs || [];
+    if (companyData.ownerId !== req.user.uid && !reps.includes(req.user.uid)) {
+      return res.status(403).json({ success: false, error: "Not authorized for this company" });
+    }
+
+    await jobRef.update({ applicationForm: admin.firestore.FieldValue.delete() });
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("Error deleting application form:", err);
+    return res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+/* ----------------------------------------------------
+   GET ALL SUBMISSIONS FOR A COMPANY
+---------------------------------------------------- */
+app.get("/api/companies/:companyId/submissions", verifyFirebaseToken, async (req, res) => {
+  try {
+    const { companyId } = req.params;
+
+    const companyDoc = await db.collection("companies").doc(companyId).get();
+    if (!companyDoc.exists) {
+      return res.status(404).json({ success: false, error: "Company not found" });
+    }
+
+    const companyData = companyDoc.data();
+    const reps = companyData.representativeIDs || [];
+    if (companyData.ownerId !== req.user.uid && !reps.includes(req.user.uid)) {
+      return res.status(403).json({ success: false, error: "Not authorized for this company" });
+    }
+
+    const snapshot = await db
+      .collection("jobApplications")
+      .where("companyId", "==", companyId)
+      .get();
+
+    const submissions = snapshot.docs
+      .map((doc) => ({ id: doc.id, ...doc.data() }))
+      .sort((a, b) => (b.submittedAt ?? 0) - (a.submittedAt ?? 0));
+
+    return res.json({ success: true, submissions });
+  } catch (err) {
+    console.error("Error fetching submissions:", err);
+    return res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+/* ----------------------------------------------------
    HELPER: Verify user is representative or company owner
 ---------------------------------------------------- */
 async function verifyRepOrOwner(userId, companyId) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.74.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hello-pangea/dnd": "^18.0.1",
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
         "firebase": "^12.4.0",
@@ -1949,6 +1950,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3140,6 +3158,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -4362,6 +4386,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css.escape": {
@@ -8483,6 +8516,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -8574,6 +8613,29 @@
       },
       "peerDependencies": {
         "react": ">=16.6.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -8687,6 +8749,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9582,6 +9650,12 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
       "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@anthropic-ai/sdk": "^0.74.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hello-pangea/dnd": "^18.0.1",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "firebase": "^12.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import JobInvitations from "./pages/JobInvitations"
 import TailorResumeSimplePage from "./pages/TailorResumeSimplePage"
 import TailoredResumeViewPage from "./pages/TailoredResumeViewPage"
 import TailoredResumesPage from "./pages/TailoredResumesPage"
+import SubmissionsPage from "./pages/SubmissionsPage"
 
 function App() {
   return (
@@ -40,6 +41,7 @@ function App() {
         <Route path="/companies" element={<CompanyManagement />} />
         <Route path="/company/:id" element={<Company />} />
         <Route path="/company/:companyId/booth" element={<BoothEditor />} />
+        <Route path="/company/:companyId/submissions" element={<SubmissionsPage />} />
         <Route path="/booths" element={<Booths />} />
         <Route path="/booth/:boothId" element={<BoothView />} />
         <Route path="/verification-pending" element={<EmailVerificationPending />} />

--- a/frontend/src/components/ApplicationFormBuilderDialog.tsx
+++ b/frontend/src/components/ApplicationFormBuilderDialog.tsx
@@ -572,9 +572,16 @@ export default function ApplicationFormBuilderDialog({
                                         <MenuItem value="singleSelect">Single select</MenuItem>
                                         <MenuItem value="multiSelect">Multi select</MenuItem>
                                         <MenuItem value="checkbox">Checkbox</MenuItem>
+                                        <MenuItem value="file">File upload</MenuItem>
                                       </Select>
                                     </FormControl>
                                   </Box>
+
+                                  {field.type === "file" && (
+                                    <Typography variant="caption" color="text.secondary">
+                                      Candidates will upload a file in this field.
+                                    </Typography>
+                                  )}
 
                                   {(field.type === "singleSelect" || field.type === "multiSelect") && (
                                     <TextField

--- a/frontend/src/components/ApplicationFormBuilderDialog.tsx
+++ b/frontend/src/components/ApplicationFormBuilderDialog.tsx
@@ -1,0 +1,541 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+  IconButton,
+  Chip,
+  Paper,
+} from "@mui/material";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+import type { DropResult } from "@hello-pangea/dnd";
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "../firebase";
+import type { ApplicationForm, FormField, FormFieldType } from "../types/applicationForm";
+
+interface ApplicationFormBuilderDialogProps {
+  open: boolean;
+  onClose: () => void;
+  jobId: string;
+  jobName: string;
+  initialForm?: ApplicationForm;
+  onSaved?: (form: ApplicationForm) => void;
+}
+
+interface FieldErrors {
+  label?: string;
+  options?: string;
+}
+
+export default function ApplicationFormBuilderDialog({
+  open,
+  onClose,
+  jobId,
+  jobName,
+  initialForm,
+  onSaved,
+}: ApplicationFormBuilderDialogProps) {
+  const [formTitle, setFormTitle] = useState("");
+  const [formDescription, setFormDescription] = useState("");
+  const [fields, setFields] = useState<FormField[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, FieldErrors>>({});
+
+  const hasExistingForm = useMemo(() => !!initialForm, [initialForm]);
+
+  useEffect(() => {
+    if (open) {
+      if (initialForm) {
+        setFormTitle(initialForm.title);
+        setFormDescription(initialForm.description ?? "");
+        setFields(initialForm.fields ?? []);
+      } else {
+        setFormTitle(`Application for ${jobName}`);
+        setFormDescription("");
+        setFields([
+          {
+            id: crypto.randomUUID(),
+            type: "shortText",
+            label: "",
+            required: true,
+          },
+        ]);
+      }
+      setError("");
+      setFieldErrors({});
+    }
+  }, [open, initialForm, jobName]);
+
+  const handleAddField = () => {
+    setFields((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        type: "shortText",
+        label: "",
+        required: false,
+      },
+    ]);
+  };
+
+  const handleDeleteField = (id: string) => {
+    setFields((prev) => prev.filter((field) => field.id !== id));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const handleFieldChange = <K extends keyof FormField>(id: string, key: K, value: FormField[K]) => {
+    setFields((prev) => prev.map((field) => (field.id === id ? { ...field, [key]: value } : field)));
+    if (key === "label" || key === "options") {
+      setFieldErrors((prev) => ({
+        ...prev,
+        [id]: {
+          ...prev[id],
+          [key === "label" ? "label" : "options"]: undefined,
+        },
+      }));
+    }
+  };
+
+  const handleFieldTypeChange = (id: string, type: FormFieldType) => {
+    setFields((prev) =>
+      prev.map((field) =>
+        field.id === id
+          ? {
+              ...field,
+              type,
+              options:
+                type === "singleSelect" || type === "multiSelect"
+                  ? field.options && field.options.length > 0
+                    ? field.options
+                    : [""]
+                  : undefined,
+            }
+          : field,
+      ),
+    );
+    setFieldErrors((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        options: undefined,
+      },
+    }));
+  };
+
+  const handleOptionsChange = (id: string, value: string) => {
+    const options = value.split(",").map((opt) => opt.trim());
+    handleFieldChange(id, "options", options);
+  };
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const newFields = Array.from(fields);
+    const [moved] = newFields.splice(result.source.index, 1);
+    newFields.splice(result.destination.index, 0, moved);
+    setFields(newFields);
+  };
+
+  const validateForm = () => {
+    const trimmedTitle = formTitle.trim();
+    if (!trimmedTitle) {
+      setError("Form title is required.");
+      return false;
+    }
+
+    if (fields.length === 0) {
+      setError("Add at least one field to your application form.");
+      return false;
+    }
+
+    const newFieldErrors: Record<string, FieldErrors> = {};
+    let hasError = false;
+
+    fields.forEach((field) => {
+      const currentErrors: FieldErrors = {};
+
+      if (!field.label.trim()) {
+        currentErrors.label = "Field label is required.";
+        hasError = true;
+      }
+
+      if (field.type === "singleSelect" || field.type === "multiSelect") {
+        const options = (field.options ?? []).map((opt) => opt.trim()).filter((opt) => opt.length > 0);
+        if (options.length === 0) {
+          currentErrors.options = "Provide at least one option.";
+          hasError = true;
+        }
+      }
+
+      if (Object.keys(currentErrors).length > 0) {
+        newFieldErrors[field.id] = currentErrors;
+      }
+    });
+
+    setFieldErrors(newFieldErrors);
+
+    if (hasError) {
+      if (!error) {
+        setError("Please fix the highlighted fields before saving.");
+      }
+      return false;
+    }
+
+    setError("");
+    return true;
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+
+    const isValid = validateForm();
+    if (!isValid) {
+      return;
+    }
+
+    const formToSave: ApplicationForm = {
+      title: formTitle.trim(),
+      ...(formDescription.trim() ? { description: formDescription.trim() } : {}),
+      fields: fields.map((field) => {
+        const base: FormField = {
+          id: field.id,
+          type: field.type,
+          label: field.label.trim(),
+          required: field.required,
+        };
+        if (field.type === "singleSelect" || field.type === "multiSelect") {
+          base.options = (field.options ?? [])
+            .map((opt) => opt.trim())
+            .filter((opt) => opt.length > 0);
+        }
+        return base;
+      }),
+      updatedAt: Date.now(),
+    };
+
+    try {
+      setSaving(true);
+      setError("");
+
+      const jobRef = doc(db, "jobs", jobId);
+      await updateDoc(jobRef, {
+        applicationForm: formToSave,
+      });
+
+      if (onSaved) {
+        onSaved(formToSave);
+      }
+      onClose();
+    } catch (err: any) {
+      // eslint-disable-next-line no-console
+      console.error("Error saving application form:", err);
+      setError(err?.message || "Failed to save application form. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: { maxHeight: "90vh" },
+      }}
+    >
+      <DialogTitle>
+        <Typography variant="h6" component="div">
+          Application Form
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {jobName}
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Box sx={{ mb: 2, display: "flex", alignItems: "flex-start", gap: 1.5 }}>
+          <InfoOutlinedIcon sx={{ color: "text.secondary", mt: 0.5 }} fontSize="small" />
+          <Typography variant="body2" color="text.secondary">
+            Define the questions candidates will answer when applying to this job during the virtual career fair.
+            {hasExistingForm ? " You can edit, reorder, or remove existing fields at any time." : " Start by customizing the title and your first question."}
+          </Typography>
+        </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
+            {error}
+          </Alert>
+        )}
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mb: 3 }}>
+          <TextField
+            fullWidth
+            label="Form title"
+            required
+            value={formTitle}
+            onChange={(e) => setFormTitle(e.target.value)}
+          />
+          <TextField
+            fullWidth
+            multiline
+            minRows={2}
+            label="Form description (optional)"
+            value={formDescription}
+            onChange={(e) => setFormDescription(e.target.value)}
+            placeholder="Share context or instructions for candidates about this application."
+          />
+        </Box>
+
+        <Divider sx={{ mb: 2 }} />
+
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            Fields
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Drag to reorder questions. Required questions are marked with an asterisk.
+          </Typography>
+        </Box>
+
+        <Box
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            p: 1,
+            maxHeight: 360,
+            overflow: "auto",
+            bgcolor: "#fafafa",
+          }}
+        >
+          {fields.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: "center" }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                No fields yet.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Use the{" "}
+                <Box component="span" sx={{ fontWeight: 600 }}>
+                  Add field
+                </Box>{" "}
+                button below to start building your form.
+              </Typography>
+            </Box>
+          ) : (
+            <DragDropContext onDragEnd={handleDragEnd}>
+              <Droppable droppableId="application-form-fields">
+                {(providedDroppable) => (
+                  <Box ref={providedDroppable.innerRef} {...providedDroppable.droppableProps} sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                    {fields.map((field, index) => {
+                      const errorsForField = fieldErrors[field.id] || {};
+                      const optionsValue = (field.options ?? []).join(", ");
+
+                      return (
+                        <Draggable key={field.id} draggableId={field.id} index={index}>
+                          {(providedDraggable, snapshot) => (
+                            <Paper
+                              ref={providedDraggable.innerRef}
+                              {...providedDraggable.draggableProps}
+                              sx={{
+                                p: 1.5,
+                                borderRadius: 1,
+                                border: "1px solid",
+                                borderColor: snapshot.isDragging ? "primary.main" : "rgba(0,0,0,0.12)",
+                                boxShadow: snapshot.isDragging ? "0 4px 12px rgba(56, 133, 96, 0.25)" : "none",
+                                backgroundColor: "background.paper",
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 1,
+                              }}
+                            >
+                              <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
+                                <Box
+                                  {...providedDraggable.dragHandleProps}
+                                  sx={{
+                                    mt: 0.5,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    color: snapshot.isDragging ? "primary.main" : "text.disabled",
+                                    cursor: "grab",
+                                  }}
+                                >
+                                  <DragIndicatorIcon fontSize="small" />
+                                </Box>
+
+                                <Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+                                  <Box sx={{ display: "flex", gap: 1 }}>
+                                    <TextField
+                                      fullWidth
+                                      size="small"
+                                      label="Field label"
+                                      required
+                                      value={field.label}
+                                      onChange={(e) => handleFieldChange(field.id, "label", e.target.value)}
+                                      error={!!errorsForField.label}
+                                      helperText={errorsForField.label}
+                                    />
+
+                                    <FormControl size="small" sx={{ minWidth: 160 }}>
+                                      <InputLabel id={`field-type-label-${field.id}`}>Type</InputLabel>
+                                      <Select
+                                        labelId={`field-type-label-${field.id}`}
+                                        label="Type"
+                                        value={field.type}
+                                        onChange={(e) =>
+                                          handleFieldTypeChange(field.id, e.target.value as FormFieldType)
+                                        }
+                                      >
+                                        <MenuItem value="shortText">Short text</MenuItem>
+                                        <MenuItem value="longText">Long text</MenuItem>
+                                        <MenuItem value="singleSelect">Single select</MenuItem>
+                                        <MenuItem value="multiSelect">Multi select</MenuItem>
+                                        <MenuItem value="checkbox">Checkbox</MenuItem>
+                                      </Select>
+                                    </FormControl>
+                                  </Box>
+
+                                  {(field.type === "singleSelect" || field.type === "multiSelect") && (
+                                    <TextField
+                                      fullWidth
+                                      size="small"
+                                      label="Options (comma-separated)"
+                                      value={optionsValue}
+                                      onChange={(e) => handleOptionsChange(field.id, e.target.value)}
+                                      error={!!errorsForField.options}
+                                      helperText={errorsForField.options || "Example: Yes, No, Maybe"}
+                                    />
+                                  )}
+
+                                  <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                                    <FormControlLabel
+                                      control={
+                                        <Checkbox
+                                          checked={field.required}
+                                          onChange={(e) => handleFieldChange(field.id, "required", e.target.checked)}
+                                        />
+                                      }
+                                      label="Required"
+                                    />
+
+                                    <IconButton
+                                      size="small"
+                                      color="error"
+                                      onClick={() => handleDeleteField(field.id)}
+                                      sx={{ ml: 1 }}
+                                    >
+                                      <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                  </Box>
+                                </Box>
+                              </Box>
+
+                              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
+                                <Chip size="small" label={`Question ${index + 1}`} />
+                                {field.type === "shortText" && (
+                                  <Chip size="small" label="Short text" variant="outlined" />
+                                )}
+                                {field.type === "longText" && (
+                                  <Chip size="small" label="Long text" variant="outlined" />
+                                )}
+                                {field.type === "singleSelect" && (
+                                  <Chip size="small" label="Single select" variant="outlined" />
+                                )}
+                                {field.type === "multiSelect" && (
+                                  <Chip size="small" label="Multi select" variant="outlined" />
+                                )}
+                                {field.type === "checkbox" && (
+                                  <Chip size="small" label="Checkbox" variant="outlined" />
+                                )}
+                                {field.required && (
+                                  <Chip size="small" color="primary" label="Required" />
+                                )}
+                              </Box>
+                            </Paper>
+                          )}
+                        </Draggable>
+                      );
+                    })}
+                    {providedDroppable.placeholder}
+                  </Box>
+                )}
+              </Droppable>
+            </DragDropContext>
+          )}
+        </Box>
+
+        <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={handleAddField}
+            sx={{
+              textTransform: "none",
+              borderRadius: 999,
+              px: 2,
+              background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+              color: "white",
+              "&:hover": {
+                background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
+              },
+            }}
+          >
+            Add field
+          </Button>
+
+          <Typography variant="caption" color="text.secondary">
+            {fields.length} field{fields.length !== 1 ? "s" : ""} configured
+          </Typography>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={saving}
+          sx={{
+            background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+            "&:hover": {
+              background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
+            },
+          }}
+        >
+          {saving ? "Saving..." : "Save form"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/frontend/src/components/ApplicationFormBuilderDialog.tsx
+++ b/frontend/src/components/ApplicationFormBuilderDialog.tsx
@@ -27,8 +27,7 @@ import AddIcon from "@mui/icons-material/Add";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import type { DropResult } from "@hello-pangea/dnd";
-import { collection, getDocs, Timestamp } from "firebase/firestore";
-import { auth, db } from "../firebase";
+import { auth } from "../firebase";
 import { API_URL } from "../config";
 import type { ApplicationForm, FormField, FormFieldType } from "../types/applicationForm";
 
@@ -46,14 +45,6 @@ interface FieldErrors {
   options?: string;
 }
 
-interface FairScheduleOption {
-  id: string;
-  name: string | null;
-  description: string | null;
-  startTime: number | null;
-  endTime: number | null;
-}
-
 export default function ApplicationFormBuilderDialog({
   open,
   onClose,
@@ -69,73 +60,8 @@ export default function ApplicationFormBuilderDialog({
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, FieldErrors>>({});
   const [formStatus, setFormStatus] = useState<"draft" | "published">("draft");
-  const [fairSchedules, setFairSchedules] = useState<FairScheduleOption[]>([]);
-  const [fairScheduleId, setFairScheduleId] = useState("");
-  const [fairSelectionError, setFairSelectionError] = useState("");
-  const [loadingFairs, setLoadingFairs] = useState(false);
 
   const hasExistingForm = useMemo(() => !!initialForm, [initialForm]);
-
-  const selectedFair = useMemo(
-    () => fairSchedules.find((schedule) => schedule.id === fairScheduleId) ?? null,
-    [fairSchedules, fairScheduleId],
-  );
-
-  const isActiveForSubmissions = useMemo(() => {
-    if (formStatus !== "published" || !selectedFair || !selectedFair.startTime || !selectedFair.endTime) {
-      return false;
-    }
-    const now = Date.now();
-    return now >= selectedFair.startTime && now <= selectedFair.endTime;
-  }, [formStatus, selectedFair]);
-
-  const fetchFairSchedules = async () => {
-    try {
-      setLoadingFairs(true);
-      const now = Date.now();
-      const snapshot = await getDocs(collection(db, "fairSchedules"));
-      const options: FairScheduleOption[] = [];
-
-      snapshot.forEach((scheduleDoc) => {
-        const data = scheduleDoc.data();
-
-        let startTime: number | null = null;
-        let endTime: number | null = null;
-
-        if (data.startTime) {
-          startTime =
-            data.startTime instanceof Timestamp ? data.startTime.toMillis() : (data.startTime as number | null);
-        }
-        if (data.endTime) {
-          endTime = data.endTime instanceof Timestamp ? data.endTime.toMillis() : (data.endTime as number | null);
-        }
-
-        if (endTime && endTime >= now) {
-          options.push({
-            id: scheduleDoc.id,
-            name: data.name || null,
-            description: data.description || null,
-            startTime,
-            endTime,
-          });
-        }
-      });
-
-      options.sort((a, b) => {
-        if (!a.startTime && !b.startTime) return 0;
-        if (!a.startTime) return 1;
-        if (!b.startTime) return -1;
-        return a.startTime - b.startTime;
-      });
-
-      setFairSchedules(options);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("Error fetching fair schedules:", err);
-    } finally {
-      setLoadingFairs(false);
-    }
-  };
 
   useEffect(() => {
     if (open) {
@@ -144,7 +70,6 @@ export default function ApplicationFormBuilderDialog({
         setFormDescription(initialForm.description ?? "");
         setFields(initialForm.fields ?? []);
         setFormStatus(initialForm.status ?? "draft");
-        setFairScheduleId(initialForm.fairScheduleId ?? "");
       } else {
         setFormTitle(`Application for ${jobName}`);
         setFormDescription("");
@@ -157,11 +82,9 @@ export default function ApplicationFormBuilderDialog({
           },
         ]);
         setFormStatus("draft");
-        setFairScheduleId("");
       }
       setError("");
       setFieldErrors({});
-      void fetchFairSchedules();
     }
   }, [open, initialForm, jobName]);
 
@@ -283,16 +206,6 @@ export default function ApplicationFormBuilderDialog({
       return false;
     }
 
-    if (formStatus === "published" && !fairScheduleId) {
-      setFairSelectionError("Select a fair for this published form.");
-      if (!error) {
-        setError("Please select a fair for this published form.");
-      }
-      return false;
-    }
-
-    setFairSelectionError("");
-
     setError("");
     return true;
   };
@@ -310,7 +223,6 @@ export default function ApplicationFormBuilderDialog({
       title: formTitle.trim(),
       status: formStatus,
       ...(formDescription.trim() ? { description: formDescription.trim() } : {}),
-      ...(formStatus === "published" && fairScheduleId ? { fairScheduleId } : {}),
       ...(formStatus === "published" ? { publishedAt: now } : {}),
       fields: fields.map((field) => {
         const base: FormField = {
@@ -397,12 +309,6 @@ export default function ApplicationFormBuilderDialog({
           </Typography>
         </Box>
 
-        {isActiveForSubmissions && (
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            This application form is currently live for the selected fair. Unpublish it to make structural changes.
-          </Alert>
-        )}
-
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
             {error}
@@ -416,7 +322,7 @@ export default function ApplicationFormBuilderDialog({
             required
             value={formTitle}
             onChange={(e) => setFormTitle(e.target.value)}
-            disabled={isActiveForSubmissions}
+
           />
           <TextField
             fullWidth
@@ -426,57 +332,23 @@ export default function ApplicationFormBuilderDialog({
             value={formDescription}
             onChange={(e) => setFormDescription(e.target.value)}
             placeholder="Share context or instructions for candidates about this application."
-            disabled={isActiveForSubmissions}
+
           />
         </Box>
 
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, alignItems: "center", mb: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
           <FormControlLabel
             control={
               <Switch
                 checked={formStatus === "published"}
                 onChange={(e) => {
-                  const nextStatus: "draft" | "published" = e.target.checked ? "published" : "draft";
-                  setFormStatus(nextStatus);
+                  setFormStatus(e.target.checked ? "published" : "draft");
                 }}
                 color="primary"
               />
             }
             label={formStatus === "published" ? "Published" : "Draft"}
           />
-
-          <FormControl size="small" sx={{ minWidth: 220 }}>
-            <InputLabel id="fair-select-label">Fair</InputLabel>
-            <Select
-              labelId="fair-select-label"
-              label="Fair"
-              value={fairScheduleId}
-              onChange={(e) => {
-                setFairScheduleId(e.target.value as string);
-                setFairSelectionError("");
-              }}
-              disabled={loadingFairs || fairSchedules.length === 0}
-            >
-              <MenuItem value="">
-                <em>No fair selected</em>
-              </MenuItem>
-              {fairSchedules.map((schedule) => (
-                <MenuItem key={schedule.id} value={schedule.id}>
-                  {schedule.name || "Untitled fair"}
-                </MenuItem>
-              ))}
-            </Select>
-            {fairSelectionError && (
-              <Typography variant="caption" color="error">
-                {fairSelectionError}
-              </Typography>
-            )}
-            {!loadingFairs && fairSchedules.length === 0 && (
-              <Typography variant="caption" color="text.secondary">
-                No upcoming or active fairs. Forms can be prepared as drafts but not published yet.
-              </Typography>
-            )}
-          </FormControl>
         </Box>
 
         <Divider sx={{ mb: 2 }} />
@@ -567,7 +439,7 @@ export default function ApplicationFormBuilderDialog({
                                       onChange={(e) => handleFieldChange(field.id, "label", e.target.value)}
                                       error={!!errorsForField.label}
                                       helperText={errorsForField.label}
-                                      disabled={isActiveForSubmissions}
+
                                     />
 
                                     <FormControl size="small" sx={{ minWidth: 160 }}>
@@ -579,7 +451,7 @@ export default function ApplicationFormBuilderDialog({
                                         onChange={(e) =>
                                           handleFieldTypeChange(field.id, e.target.value as FormFieldType)
                                         }
-                                        disabled={isActiveForSubmissions}
+
                                       >
                                         <MenuItem value="shortText">Short text</MenuItem>
                                         <MenuItem value="longText">Long text</MenuItem>
@@ -606,7 +478,7 @@ export default function ApplicationFormBuilderDialog({
                                       onChange={(e) => handleOptionsChange(field.id, e.target.value)}
                                       error={!!errorsForField.options}
                                       helperText={errorsForField.options || "Example: Yes, No, Maybe"}
-                                      disabled={isActiveForSubmissions}
+
                                     />
                                   )}
 
@@ -616,7 +488,7 @@ export default function ApplicationFormBuilderDialog({
                                         <Checkbox
                                           checked={field.required}
                                           onChange={(e) => handleFieldChange(field.id, "required", e.target.checked)}
-                                          disabled={isActiveForSubmissions}
+
                                         />
                                       }
                                       label="Required"
@@ -627,7 +499,7 @@ export default function ApplicationFormBuilderDialog({
                                       color="error"
                                       onClick={() => handleDeleteField(field.id)}
                                       sx={{ ml: 1 }}
-                                      disabled={isActiveForSubmissions}
+
                                     >
                                       <DeleteIcon fontSize="small" />
                                     </IconButton>
@@ -684,7 +556,7 @@ export default function ApplicationFormBuilderDialog({
                 background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
               },
             }}
-            disabled={isActiveForSubmissions}
+
           >
             Add field
           </Button>

--- a/frontend/src/components/ApplicationFormBuilderDialog.tsx
+++ b/frontend/src/components/ApplicationFormBuilderDialog.tsx
@@ -27,8 +27,9 @@ import AddIcon from "@mui/icons-material/Add";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import type { DropResult } from "@hello-pangea/dnd";
-import { collection, doc, getDocs, Timestamp, updateDoc } from "firebase/firestore";
-import { db } from "../firebase";
+import { collection, getDocs, Timestamp } from "firebase/firestore";
+import { auth, db } from "../firebase";
+import { API_URL } from "../config";
 import type { ApplicationForm, FormField, FormFieldType } from "../types/applicationForm";
 
 interface ApplicationFormBuilderDialogProps {
@@ -332,10 +333,23 @@ export default function ApplicationFormBuilderDialog({
       setSaving(true);
       setError("");
 
-      const jobRef = doc(db, "jobs", jobId);
-      await updateDoc(jobRef, {
-        applicationForm: formToSave,
-      });
+      const token = await auth.currentUser?.getIdToken();
+      const response = await fetch(
+        `${API_URL}/api/jobs/${jobId}/form`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(formToSave),
+        },
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to save application form.");
+      }
 
       if (onSaved) {
         onSaved(formToSave);

--- a/frontend/src/components/ApplicationFormBuilderDialog.tsx
+++ b/frontend/src/components/ApplicationFormBuilderDialog.tsx
@@ -14,6 +14,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Switch,
   TextField,
   Typography,
   IconButton,
@@ -26,7 +27,7 @@ import AddIcon from "@mui/icons-material/Add";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import type { DropResult } from "@hello-pangea/dnd";
-import { doc, updateDoc } from "firebase/firestore";
+import { collection, doc, getDocs, Timestamp, updateDoc } from "firebase/firestore";
 import { db } from "../firebase";
 import type { ApplicationForm, FormField, FormFieldType } from "../types/applicationForm";
 
@@ -44,6 +45,14 @@ interface FieldErrors {
   options?: string;
 }
 
+interface FairScheduleOption {
+  id: string;
+  name: string | null;
+  description: string | null;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export default function ApplicationFormBuilderDialog({
   open,
   onClose,
@@ -58,8 +67,74 @@ export default function ApplicationFormBuilderDialog({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, FieldErrors>>({});
+  const [formStatus, setFormStatus] = useState<"draft" | "published">("draft");
+  const [fairSchedules, setFairSchedules] = useState<FairScheduleOption[]>([]);
+  const [fairScheduleId, setFairScheduleId] = useState("");
+  const [fairSelectionError, setFairSelectionError] = useState("");
+  const [loadingFairs, setLoadingFairs] = useState(false);
 
   const hasExistingForm = useMemo(() => !!initialForm, [initialForm]);
+
+  const selectedFair = useMemo(
+    () => fairSchedules.find((schedule) => schedule.id === fairScheduleId) ?? null,
+    [fairSchedules, fairScheduleId],
+  );
+
+  const isActiveForSubmissions = useMemo(() => {
+    if (formStatus !== "published" || !selectedFair || !selectedFair.startTime || !selectedFair.endTime) {
+      return false;
+    }
+    const now = Date.now();
+    return now >= selectedFair.startTime && now <= selectedFair.endTime;
+  }, [formStatus, selectedFair]);
+
+  const fetchFairSchedules = async () => {
+    try {
+      setLoadingFairs(true);
+      const now = Date.now();
+      const snapshot = await getDocs(collection(db, "fairSchedules"));
+      const options: FairScheduleOption[] = [];
+
+      snapshot.forEach((scheduleDoc) => {
+        const data = scheduleDoc.data();
+
+        let startTime: number | null = null;
+        let endTime: number | null = null;
+
+        if (data.startTime) {
+          startTime =
+            data.startTime instanceof Timestamp ? data.startTime.toMillis() : (data.startTime as number | null);
+        }
+        if (data.endTime) {
+          endTime = data.endTime instanceof Timestamp ? data.endTime.toMillis() : (data.endTime as number | null);
+        }
+
+        if (endTime && endTime >= now) {
+          options.push({
+            id: scheduleDoc.id,
+            name: data.name || null,
+            description: data.description || null,
+            startTime,
+            endTime,
+          });
+        }
+      });
+
+      options.sort((a, b) => {
+        if (!a.startTime && !b.startTime) return 0;
+        if (!a.startTime) return 1;
+        if (!b.startTime) return -1;
+        return a.startTime - b.startTime;
+      });
+
+      setFairSchedules(options);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Error fetching fair schedules:", err);
+    } finally {
+      setLoadingFairs(false);
+    }
+  };
 
   useEffect(() => {
     if (open) {
@@ -67,6 +142,8 @@ export default function ApplicationFormBuilderDialog({
         setFormTitle(initialForm.title);
         setFormDescription(initialForm.description ?? "");
         setFields(initialForm.fields ?? []);
+        setFormStatus(initialForm.status ?? "draft");
+        setFairScheduleId(initialForm.fairScheduleId ?? "");
       } else {
         setFormTitle(`Application for ${jobName}`);
         setFormDescription("");
@@ -78,9 +155,12 @@ export default function ApplicationFormBuilderDialog({
             required: true,
           },
         ]);
+        setFormStatus("draft");
+        setFairScheduleId("");
       }
       setError("");
       setFieldErrors({});
+      void fetchFairSchedules();
     }
   }, [open, initialForm, jobName]);
 
@@ -202,6 +282,16 @@ export default function ApplicationFormBuilderDialog({
       return false;
     }
 
+    if (formStatus === "published" && !fairScheduleId) {
+      setFairSelectionError("Select a fair for this published form.");
+      if (!error) {
+        setError("Please select a fair for this published form.");
+      }
+      return false;
+    }
+
+    setFairSelectionError("");
+
     setError("");
     return true;
   };
@@ -214,9 +304,13 @@ export default function ApplicationFormBuilderDialog({
       return;
     }
 
+    const now = Date.now();
     const formToSave: ApplicationForm = {
       title: formTitle.trim(),
+      status: formStatus,
       ...(formDescription.trim() ? { description: formDescription.trim() } : {}),
+      ...(formStatus === "published" && fairScheduleId ? { fairScheduleId } : {}),
+      ...(formStatus === "published" ? { publishedAt: now } : {}),
       fields: fields.map((field) => {
         const base: FormField = {
           id: field.id,
@@ -231,7 +325,7 @@ export default function ApplicationFormBuilderDialog({
         }
         return base;
       }),
-      updatedAt: Date.now(),
+      updatedAt: now,
     };
 
     try {
@@ -289,6 +383,12 @@ export default function ApplicationFormBuilderDialog({
           </Typography>
         </Box>
 
+        {isActiveForSubmissions && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            This application form is currently live for the selected fair. Unpublish it to make structural changes.
+          </Alert>
+        )}
+
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
             {error}
@@ -302,6 +402,7 @@ export default function ApplicationFormBuilderDialog({
             required
             value={formTitle}
             onChange={(e) => setFormTitle(e.target.value)}
+            disabled={isActiveForSubmissions}
           />
           <TextField
             fullWidth
@@ -311,7 +412,57 @@ export default function ApplicationFormBuilderDialog({
             value={formDescription}
             onChange={(e) => setFormDescription(e.target.value)}
             placeholder="Share context or instructions for candidates about this application."
+            disabled={isActiveForSubmissions}
           />
+        </Box>
+
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, alignItems: "center", mb: 2 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={formStatus === "published"}
+                onChange={(e) => {
+                  const nextStatus: "draft" | "published" = e.target.checked ? "published" : "draft";
+                  setFormStatus(nextStatus);
+                }}
+                color="primary"
+              />
+            }
+            label={formStatus === "published" ? "Published" : "Draft"}
+          />
+
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel id="fair-select-label">Fair</InputLabel>
+            <Select
+              labelId="fair-select-label"
+              label="Fair"
+              value={fairScheduleId}
+              onChange={(e) => {
+                setFairScheduleId(e.target.value as string);
+                setFairSelectionError("");
+              }}
+              disabled={loadingFairs || fairSchedules.length === 0}
+            >
+              <MenuItem value="">
+                <em>No fair selected</em>
+              </MenuItem>
+              {fairSchedules.map((schedule) => (
+                <MenuItem key={schedule.id} value={schedule.id}>
+                  {schedule.name || "Untitled fair"}
+                </MenuItem>
+              ))}
+            </Select>
+            {fairSelectionError && (
+              <Typography variant="caption" color="error">
+                {fairSelectionError}
+              </Typography>
+            )}
+            {!loadingFairs && fairSchedules.length === 0 && (
+              <Typography variant="caption" color="text.secondary">
+                No upcoming or active fairs. Forms can be prepared as drafts but not published yet.
+              </Typography>
+            )}
+          </FormControl>
         </Box>
 
         <Divider sx={{ mb: 2 }} />
@@ -402,6 +553,7 @@ export default function ApplicationFormBuilderDialog({
                                       onChange={(e) => handleFieldChange(field.id, "label", e.target.value)}
                                       error={!!errorsForField.label}
                                       helperText={errorsForField.label}
+                                      disabled={isActiveForSubmissions}
                                     />
 
                                     <FormControl size="small" sx={{ minWidth: 160 }}>
@@ -413,6 +565,7 @@ export default function ApplicationFormBuilderDialog({
                                         onChange={(e) =>
                                           handleFieldTypeChange(field.id, e.target.value as FormFieldType)
                                         }
+                                        disabled={isActiveForSubmissions}
                                       >
                                         <MenuItem value="shortText">Short text</MenuItem>
                                         <MenuItem value="longText">Long text</MenuItem>
@@ -432,6 +585,7 @@ export default function ApplicationFormBuilderDialog({
                                       onChange={(e) => handleOptionsChange(field.id, e.target.value)}
                                       error={!!errorsForField.options}
                                       helperText={errorsForField.options || "Example: Yes, No, Maybe"}
+                                      disabled={isActiveForSubmissions}
                                     />
                                   )}
 
@@ -441,6 +595,7 @@ export default function ApplicationFormBuilderDialog({
                                         <Checkbox
                                           checked={field.required}
                                           onChange={(e) => handleFieldChange(field.id, "required", e.target.checked)}
+                                          disabled={isActiveForSubmissions}
                                         />
                                       }
                                       label="Required"
@@ -451,6 +606,7 @@ export default function ApplicationFormBuilderDialog({
                                       color="error"
                                       onClick={() => handleDeleteField(field.id)}
                                       sx={{ ml: 1 }}
+                                      disabled={isActiveForSubmissions}
                                     >
                                       <DeleteIcon fontSize="small" />
                                     </IconButton>
@@ -507,6 +663,7 @@ export default function ApplicationFormBuilderDialog({
                 background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
               },
             }}
+            disabled={isActiveForSubmissions}
           >
             Add field
           </Button>

--- a/frontend/src/components/JobApplicationFormDialog.tsx
+++ b/frontend/src/components/JobApplicationFormDialog.tsx
@@ -1,0 +1,353 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { collection, addDoc } from "firebase/firestore";
+import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
+import { db, storage } from "../firebase";
+import type { ApplicationForm, FormField, FormFieldType } from "../types/applicationForm";
+
+interface JobForApply {
+  id: string;
+  companyId: string;
+  name: string;
+  applicationForm?: ApplicationForm | null;
+}
+
+interface JobApplicationFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  job: JobForApply;
+  boothId?: string;
+  studentId: string | null;
+}
+
+type FieldValue = string | string[] | boolean | File | null;
+
+export default function JobApplicationFormDialog({
+  open,
+  onClose,
+  job,
+  boothId,
+  studentId,
+}: JobApplicationFormDialogProps) {
+  const form = job.applicationForm;
+  const [values, setValues] = useState<Record<string, FieldValue>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [topError, setTopError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  if (!form || form.status !== "published") {
+    return null;
+  }
+
+  const handleChange = (field: FormField, value: FieldValue) => {
+    setValues((prev) => ({ ...prev, [field.id]: value }));
+    setErrors((prev) => ({ ...prev, [field.id]: "" }));
+    setTopError("");
+  };
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {};
+
+    for (const field of form.fields) {
+      if (!field.required) continue;
+
+      const v = values[field.id];
+
+      if (field.type === "shortText" || field.type === "longText") {
+        if (!v || typeof v !== "string" || !v.trim()) {
+          newErrors[field.id] = "This field is required.";
+        }
+      } else if (field.type === "singleSelect") {
+        if (!v || typeof v !== "string") {
+          newErrors[field.id] = "Please select an option.";
+        }
+      } else if (field.type === "multiSelect") {
+        if (!Array.isArray(v) || v.length === 0) {
+          newErrors[field.id] = "Select at least one option.";
+        }
+      } else if (field.type === "file") {
+        if (!v || !(v instanceof File)) {
+          newErrors[field.id] = "Please select a file.";
+        }
+      }
+    }
+
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) {
+      setTopError("Please fix the highlighted fields before submitting.");
+      return false;
+    }
+    return true;
+  };
+
+  const isFormValid = () => {
+    if (!form.title.trim()) return false;
+    for (const field of form.fields) {
+      if (!field.required) continue;
+      const v = values[field.id];
+      if (field.type === "shortText" || field.type === "longText") {
+        if (!v || typeof v !== "string" || !v.trim()) return false;
+      } else if (field.type === "singleSelect") {
+        if (!v || typeof v !== "string") return false;
+      } else if (field.type === "multiSelect") {
+        if (!Array.isArray(v) || v.length === 0) return false;
+      } else if (field.type === "file") {
+        if (!v || !(v instanceof File)) return false;
+      }
+    }
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!studentId) {
+      setTopError("You must be logged in as a student to apply.");
+      return;
+    }
+
+    if (!validate()) return;
+
+    try {
+      setSubmitting(true);
+      setTopError("");
+      setSuccess(false);
+
+      const responses: Record<string, any> = {};
+      const fileUrls: Record<string, string> = {};
+
+      for (const field of form.fields) {
+        const v = values[field.id];
+        if (field.type === "file" && v instanceof File) {
+          const safeName = v.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+          const storageRef = ref(
+            storage,
+            `jobApplications/${job.id}/${studentId}/${field.id}_${safeName}`,
+          );
+          const uploadTask = uploadBytesResumable(storageRef, v);
+          const url = await new Promise<string>((resolve, reject) => {
+            uploadTask.on(
+              "state_changed",
+              undefined,
+              (err) => reject(err),
+              async () => {
+                const downloadUrl = await getDownloadURL(uploadTask.snapshot.ref);
+                resolve(downloadUrl);
+              },
+            );
+          });
+          fileUrls[field.id] = url;
+        } else if (field.type !== "file") {
+          responses[field.id] = v ?? null;
+        }
+      }
+
+      const docData: any = {
+        jobId: job.id,
+        companyId: job.companyId,
+        studentId,
+        ...(boothId ? { boothId } : {}),
+        responses,
+        ...(Object.keys(fileUrls).length > 0 ? { fileUrls } : {}),
+        submittedAt: Date.now(),
+      };
+
+      await addDoc(collection(db, "jobApplications"), docData);
+      setSuccess(true);
+    } catch (err: any) {
+      // eslint-disable-next-line no-console
+      console.error("Error submitting application:", err);
+      setTopError(err?.message || "Failed to submit application. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderField = (field: FormField) => {
+    const value = values[field.id];
+
+    switch (field.type as FormFieldType) {
+      case "shortText":
+        return (
+          <TextField
+            fullWidth
+            label={field.label}
+            required={field.required}
+            value={(value as string) || ""}
+            onChange={(e) => handleChange(field, e.target.value)}
+            error={!!errors[field.id]}
+            helperText={errors[field.id]}
+          />
+        );
+      case "longText":
+        return (
+          <TextField
+            fullWidth
+            multiline
+            minRows={3}
+            label={field.label}
+            required={field.required}
+            value={(value as string) || ""}
+            onChange={(e) => handleChange(field, e.target.value)}
+            error={!!errors[field.id]}
+            helperText={errors[field.id]}
+          />
+        );
+      case "singleSelect":
+        return (
+          <FormControl fullWidth error={!!errors[field.id]}>
+            <InputLabel>{field.label}</InputLabel>
+            <Select
+              label={field.label}
+              value={(value as string) || ""}
+              onChange={(e) => handleChange(field, e.target.value)}
+              required={field.required}
+            >
+              {(field.options ?? []).map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors[field.id] && (
+              <Typography variant="caption" color="error">
+                {errors[field.id]}
+              </Typography>
+            )}
+          </FormControl>
+        );
+      case "multiSelect":
+        return (
+          <FormControl fullWidth error={!!errors[field.id]}>
+            <InputLabel>{field.label}</InputLabel>
+            <Select
+              multiple
+              label={field.label}
+              value={(value as string[]) || []}
+              onChange={(e) => handleChange(field, e.target.value as string[])}
+            >
+              {(field.options ?? []).map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors[field.id] && (
+              <Typography variant="caption" color="error">
+                {errors[field.id]}
+              </Typography>
+            )}
+          </FormControl>
+        );
+      case "checkbox":
+        return (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(value)}
+                onChange={(e) => handleChange(field, e.target.checked)}
+              />
+            }
+            label={field.label}
+          />
+        );
+      case "file":
+        return (
+          <Box>
+            <Typography variant="body2" sx={{ mb: 0.5 }}>
+              {field.label}
+              {field.required && " *"}
+            </Typography>
+            <Button variant="outlined" component="label" size="small">
+              Choose file
+              <input
+                type="file"
+                hidden
+                onChange={(e) => {
+                  const file = e.target.files?.[0] || null;
+                  handleChange(field, file);
+                }}
+              />
+            </Button>
+            {value instanceof File && (
+              <Typography variant="caption" sx={{ ml: 1 }}>
+                {value.name}
+              </Typography>
+            )}
+            {errors[field.id] && (
+              <Typography variant="caption" color="error" display="block">
+                {errors[field.id]}
+              </Typography>
+            )}
+          </Box>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{form.title}</DialogTitle>
+      <DialogContent dividers>
+        {form.description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {form.description}
+          </Typography>
+        )}
+
+        {topError && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setTopError("")}>
+            {topError}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            Application submitted successfully!
+          </Alert>
+        )}
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {form.fields.map((field) => (
+            <Box key={field.id}>{renderField(field)}</Box>
+          ))}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting || !isFormValid() || !!success}
+          sx={{
+            background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+            "&:hover": {
+              background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
+            },
+          }}
+        >
+          {submitting ? "Submitting..." : "Submit Application"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/frontend/src/components/JobApplicationFormDialog.tsx
+++ b/frontend/src/components/JobApplicationFormDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
   FormControl,
   FormControlLabel,
-  InputLabel,
   MenuItem,
   Select,
   TextField,
@@ -178,101 +177,128 @@ export default function JobApplicationFormDialog({
     }
   };
 
+  const renderFieldLabel = (field: FormField) => (
+    <Typography variant="body2" fontWeight={600} sx={{ mb: 0.75 }}>
+      {field.label}
+      {field.required && (
+        <Typography component="span" color="error" variant="body2">
+          {" "}*
+        </Typography>
+      )}
+    </Typography>
+  );
+
   const renderField = (field: FormField) => {
     const value = values[field.id];
 
     switch (field.type as FormFieldType) {
       case "shortText":
         return (
-          <TextField
-            fullWidth
-            label={field.label}
-            required={field.required}
-            value={(value as string) || ""}
-            onChange={(e) => handleChange(field, e.target.value)}
-            error={!!errors[field.id]}
-            helperText={errors[field.id]}
-          />
+          <Box>
+            {renderFieldLabel(field)}
+            <TextField
+              fullWidth
+              value={(value as string) || ""}
+              onChange={(e) => handleChange(field, e.target.value)}
+              error={!!errors[field.id]}
+              helperText={errors[field.id]}
+            />
+          </Box>
         );
       case "longText":
         return (
-          <TextField
-            fullWidth
-            multiline
-            minRows={3}
-            label={field.label}
-            required={field.required}
-            value={(value as string) || ""}
-            onChange={(e) => handleChange(field, e.target.value)}
-            error={!!errors[field.id]}
-            helperText={errors[field.id]}
-          />
+          <Box>
+            {renderFieldLabel(field)}
+            <TextField
+              fullWidth
+              multiline
+              minRows={3}
+              value={(value as string) || ""}
+              onChange={(e) => handleChange(field, e.target.value)}
+              error={!!errors[field.id]}
+              helperText={errors[field.id]}
+            />
+          </Box>
         );
       case "singleSelect":
         return (
-          <FormControl fullWidth error={!!errors[field.id]}>
-            <InputLabel>{field.label}</InputLabel>
-            <Select
-              label={field.label}
-              value={(value as string) || ""}
-              onChange={(e) => handleChange(field, e.target.value)}
-              required={field.required}
-            >
-              {(field.options ?? []).map((opt) => (
-                <MenuItem key={opt} value={opt}>
-                  {opt}
+          <Box>
+            {renderFieldLabel(field)}
+            <FormControl fullWidth error={!!errors[field.id]}>
+              <Select
+                displayEmpty
+                value={(value as string) || ""}
+                onChange={(e) => handleChange(field, e.target.value)}
+              >
+                <MenuItem value="" disabled>
+                  <em>Select an option</em>
                 </MenuItem>
-              ))}
-            </Select>
-            {errors[field.id] && (
-              <Typography variant="caption" color="error">
-                {errors[field.id]}
-              </Typography>
-            )}
-          </FormControl>
+                {(field.options ?? []).map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    {opt}
+                  </MenuItem>
+                ))}
+              </Select>
+              {errors[field.id] && (
+                <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
+                  {errors[field.id]}
+                </Typography>
+              )}
+            </FormControl>
+          </Box>
         );
       case "multiSelect":
         return (
-          <FormControl fullWidth error={!!errors[field.id]}>
-            <InputLabel>{field.label}</InputLabel>
-            <Select
-              multiple
-              label={field.label}
-              value={(value as string[]) || []}
-              onChange={(e) => handleChange(field, e.target.value as string[])}
-            >
-              {(field.options ?? []).map((opt) => (
-                <MenuItem key={opt} value={opt}>
-                  {opt}
-                </MenuItem>
-              ))}
-            </Select>
-            {errors[field.id] && (
-              <Typography variant="caption" color="error">
-                {errors[field.id]}
-              </Typography>
-            )}
-          </FormControl>
+          <Box>
+            {renderFieldLabel(field)}
+            <FormControl fullWidth error={!!errors[field.id]}>
+              <Select
+                multiple
+                displayEmpty
+                value={(value as string[]) || []}
+                onChange={(e) => handleChange(field, e.target.value as string[])}
+                renderValue={(selected) =>
+                  (selected as string[]).length === 0 ? (
+                    <em style={{ color: "rgba(0,0,0,0.4)" }}>Select options</em>
+                  ) : (
+                    (selected as string[]).join(", ")
+                  )
+                }
+              >
+                {(field.options ?? []).map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    {opt}
+                  </MenuItem>
+                ))}
+              </Select>
+              {errors[field.id] && (
+                <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
+                  {errors[field.id]}
+                </Typography>
+              )}
+            </FormControl>
+          </Box>
         );
       case "checkbox":
         return (
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={Boolean(value)}
-                onChange={(e) => handleChange(field, e.target.checked)}
-              />
-            }
-            label={field.label}
-          />
+          <Box>
+            {renderFieldLabel(field)}
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={Boolean(value)}
+                  onChange={(e) => handleChange(field, e.target.checked)}
+                />
+              }
+              label="Yes"
+              sx={{ ml: 0 }}
+            />
+          </Box>
         );
       case "file":
         return (
           <Box>
-            <Typography variant="body2" sx={{ mb: 0.5 }}>
-              {field.label}
-              {field.required && " *"}
-            </Typography>
+            {renderFieldLabel(field)}
             <Button variant="outlined" component="label" size="small">
               Choose file
               <input
@@ -290,7 +316,7 @@ export default function JobApplicationFormDialog({
               </Typography>
             )}
             {errors[field.id] && (
-              <Typography variant="caption" color="error" display="block">
+              <Typography variant="caption" color="error" display="block" sx={{ mt: 0.5 }}>
                 {errors[field.id]}
               </Typography>
             )}

--- a/frontend/src/components/SubmissionsViewerDialog.tsx
+++ b/frontend/src/components/SubmissionsViewerDialog.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Link,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import AssignmentIcon from "@mui/icons-material/Assignment";
+import { auth } from "../firebase";
+import { API_URL } from "../config";
+import type { ApplicationForm } from "../types/applicationForm";
+
+interface Submission {
+  id: string;
+  jobId: string;
+  companyId: string;
+  studentId: string;
+  responses: Record<string, string | string[] | boolean | null>;
+  fileUrls?: Record<string, string>;
+  submittedAt: number;
+}
+
+interface Job {
+  id: string;
+  name: string;
+  applicationForm?: ApplicationForm;
+}
+
+interface SubmissionsViewerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  companyId: string;
+  jobs: Job[];
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+function renderResponseValue(value: string | string[] | boolean | null): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "—";
+  return String(value) || "—";
+}
+
+function SubmissionCard({ submission, form }: { submission: Submission; form?: ApplicationForm }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid rgba(56, 133, 96, 0.2)",
+        borderRadius: 1,
+        mb: 1,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 2,
+          py: 1.25,
+          cursor: "pointer",
+          bgcolor: "rgba(56, 133, 96, 0.04)",
+          "&:hover": { bgcolor: "rgba(56, 133, 96, 0.08)" },
+        }}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <Box>
+          <Typography variant="body2" fontWeight={600} color="text.primary">
+            Applicant ID: {submission.studentId}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Submitted: {formatDate(submission.submittedAt)}
+          </Typography>
+        </Box>
+        <IconButton size="small">
+          {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+        </IconButton>
+      </Box>
+
+      <Collapse in={expanded}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          {form && form.fields.length > 0 ? (
+            form.fields.map((field) => {
+              const value = submission.responses?.[field.id];
+              const fileUrl = submission.fileUrls?.[field.id];
+              return (
+                <Box key={field.id} sx={{ mb: 1.25 }}>
+                  <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                    {field.label}
+                    {field.required && (
+                      <Typography component="span" color="error" variant="caption">
+                        {" "}*
+                      </Typography>
+                    )}
+                  </Typography>
+                  {field.type === "file" ? (
+                    fileUrl ? (
+                      <Box>
+                        <Link href={fileUrl} target="_blank" rel="noopener noreferrer" variant="body2">
+                          View uploaded file
+                        </Link>
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No file uploaded
+                      </Typography>
+                    )
+                  ) : (
+                    <Typography variant="body2" color="text.primary" sx={{ mt: 0.25 }}>
+                      {renderResponseValue(value ?? null)}
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })
+          ) : (
+            <Box>
+              {Object.entries(submission.responses ?? {}).map(([key, val]) => (
+                <Box key={key} sx={{ mb: 1 }}>
+                  <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                    {key}
+                  </Typography>
+                  <Typography variant="body2">{renderResponseValue(val)}</Typography>
+                </Box>
+              ))}
+              {submission.fileUrls &&
+                Object.entries(submission.fileUrls).map(([key, url]) => (
+                  <Box key={key} sx={{ mb: 1 }}>
+                    <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                      {key} (file)
+                    </Typography>
+                    <Box>
+                      <Link href={url} target="_blank" rel="noopener noreferrer" variant="body2">
+                        View uploaded file
+                      </Link>
+                    </Box>
+                  </Box>
+                ))}
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+export default function SubmissionsViewerDialog({
+  open,
+  onClose,
+  companyId,
+  jobs,
+}: SubmissionsViewerDialogProps) {
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [filterJobId, setFilterJobId] = useState<string>("all");
+
+  useEffect(() => {
+    if (!open) return;
+
+    const fetchSubmissions = async () => {
+      try {
+        setLoading(true);
+        setError("");
+
+        const token = await auth.currentUser?.getIdToken();
+        const response = await fetch(
+          `${API_URL}/api/companies/${companyId}/submissions`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
+
+        if (!response.ok) {
+          const data = await response.json();
+          throw new Error(data.error || "Failed to load submissions.");
+        }
+
+        const data = await response.json();
+        setSubmissions(data.submissions ?? []);
+      } catch (err: any) {
+        // eslint-disable-next-line no-console
+        console.error("Error fetching submissions:", err);
+        setError(err?.message || "Failed to load submissions.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSubmissions();
+  }, [open, companyId]);
+
+  const jobsWithForms = jobs.filter((j) => j.applicationForm);
+
+  const filteredSubmissions =
+    filterJobId === "all" ? submissions : submissions.filter((s) => s.jobId === filterJobId);
+
+  const jobMap = new Map(jobs.map((j) => [j.id, j]));
+
+  const grouped = filteredSubmissions.reduce<Record<string, Submission[]>>((acc, sub) => {
+    const key = sub.jobId;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(sub);
+    return acc;
+  }, {});
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth PaperProps={{ sx: { maxHeight: "90vh" } }}>
+      <DialogTitle>
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <AssignmentIcon sx={{ color: "#388560" }} />
+            <Typography variant="h6">Application Submissions</Typography>
+          </Box>
+          <IconButton size="small" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {/* Filter */}
+        <Box sx={{ mb: 2, display: "flex", alignItems: "center", gap: 2 }}>
+          <Typography variant="body2" color="text.secondary" flexShrink={0}>
+            Filter by job:
+          </Typography>
+          <Select
+            size="small"
+            value={filterJobId}
+            onChange={(e) => setFilterJobId(e.target.value)}
+            sx={{ minWidth: 200 }}
+          >
+            <MenuItem value="all">All jobs</MenuItem>
+            {jobs.map((j) => (
+              <MenuItem key={j.id} value={j.id}>
+                {j.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+
+        {loading && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress size={28} sx={{ color: "#388560" }} />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {!loading && !error && filteredSubmissions.length === 0 && (
+          <Box sx={{ textAlign: "center", py: 6 }}>
+            <AssignmentIcon sx={{ fontSize: 48, color: "text.disabled", mb: 1 }} />
+            <Typography color="text.secondary">No submissions yet.</Typography>
+            {jobsWithForms.length === 0 && (
+              <Typography variant="caption" color="text.disabled" display="block" mt={0.5}>
+                Publish an application form on a job to start receiving submissions.
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {!loading &&
+          !error &&
+          Object.entries(grouped).map(([jobId, jobSubs]) => {
+            const job = jobMap.get(jobId);
+            return (
+              <Box key={jobId} sx={{ mb: 3 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                  <Typography variant="subtitle2" fontWeight={700} color="#388560">
+                    {job?.name ?? jobId}
+                  </Typography>
+                  <Chip label={`${jobSubs.length} submission${jobSubs.length !== 1 ? "s" : ""}`} size="small" />
+                </Box>
+                <Divider sx={{ mb: 1.5 }} />
+                {jobSubs.map((sub) => (
+                  <SubmissionCard key={sub.id} submission={sub} form={job?.applicationForm} />
+                ))}
+              </Box>
+            );
+          })}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/__tests__/ApplicationFormBuilderDialog.test.tsx
+++ b/frontend/src/components/__tests__/ApplicationFormBuilderDialog.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import ApplicationFormBuilderDialog from "../ApplicationFormBuilderDialog"
+import type { ApplicationForm } from "../../types/applicationForm"
+
+/* ---- Firebase mocks ---- */
+vi.mock("../../firebase", () => ({
+  db: {},
+  auth: {
+    currentUser: { getIdToken: vi.fn().mockResolvedValue("mock-token") },
+  },
+}))
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  getDocs: vi.fn().mockResolvedValue({ forEach: vi.fn() }),
+}))
+
+/* ---- Config mock ---- */
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
+}))
+
+/* ---- fetch mock ---- */
+global.fetch = vi.fn()
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  jobId: "job-1",
+  jobName: "Software Engineer",
+  onSaved: vi.fn(),
+}
+
+const existingForm: ApplicationForm = {
+  title: "My Form",
+  description: "Fill this in",
+  status: "draft",
+  fields: [
+    { id: "f1", type: "shortText", label: "Your name", required: true },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(global.fetch as any).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ success: true }),
+  })
+})
+
+describe("ApplicationFormBuilderDialog", () => {
+  describe("Rendering", () => {
+    it("renders dialog with Application Form title", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      expect(screen.getByText("Application Form")).toBeInTheDocument()
+    })
+
+    it("renders job name as subtitle", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      expect(screen.getByText("Software Engineer")).toBeInTheDocument()
+    })
+
+    it("renders form title input pre-filled with job name for new form", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      const titleInput = screen.getByDisplayValue("Application for Software Engineer")
+      expect(titleInput).toBeInTheDocument()
+    })
+
+    it("pre-fills title and description when editing an existing form", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+      expect(screen.getByDisplayValue("My Form")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Fill this in")).toBeInTheDocument()
+    })
+
+    it("renders draft/published toggle switch", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      expect(screen.getByRole("checkbox")).toBeInTheDocument()
+      expect(screen.getByText("Draft")).toBeInTheDocument()
+    })
+
+    it("shows Published label when form status is published", () => {
+      const publishedForm: ApplicationForm = { ...existingForm, status: "published" }
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={publishedForm} />)
+      expect(screen.getByText("Published")).toBeInTheDocument()
+    })
+
+    it("does NOT render a fair schedule dropdown", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      // "No fair selected" was the placeholder option in the removed dropdown
+      expect(screen.queryByText("No fair selected")).not.toBeInTheDocument()
+      // There should be no Select labelled "Fair"
+      expect(screen.queryByLabelText(/^fair$/i)).not.toBeInTheDocument()
+    })
+
+    it("renders Add field button", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      expect(screen.getByRole("button", { name: /add field/i })).toBeInTheDocument()
+    })
+
+    it("renders Save and Cancel buttons", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+      expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    })
+  })
+
+  describe("Field management", () => {
+    it("adds a new field when Add field is clicked", async () => {
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+
+      const before = screen.queryAllByLabelText(/field label/i).length
+      await user.click(screen.getByRole("button", { name: /add field/i }))
+      const after = screen.queryAllByLabelText(/field label/i).length
+
+      expect(after).toBeGreaterThan(before)
+    })
+
+    it("loads existing fields when editing a form", () => {
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+      expect(screen.getByDisplayValue("Your name")).toBeInTheDocument()
+    })
+  })
+
+  describe("Validation", () => {
+    it("shows error when trying to save with a field that has no label", async () => {
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+
+      // Add a blank field (pre-filled with blank label)
+      await user.click(screen.getByRole("button", { name: /add field/i }))
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument()
+      })
+    })
+
+    it("shows error when form title is empty", async () => {
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} />)
+
+      const titleInput = screen.getByDisplayValue("Application for Software Engineer")
+      await user.clear(titleInput)
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("Save API call", () => {
+    it("calls PUT /api/jobs/:id/form with Bearer token on successful save", async () => {
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          "http://localhost:5000/api/jobs/job-1/form",
+          expect.objectContaining({
+            method: "PUT",
+            headers: expect.objectContaining({
+              Authorization: "Bearer mock-token",
+              "Content-Type": "application/json",
+            }),
+          })
+        )
+      })
+    })
+
+    it("calls onSaved callback with the form after successful save", async () => {
+      const user = userEvent.setup()
+      const onSaved = vi.fn()
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} onSaved={onSaved} />)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(onSaved).toHaveBeenCalledWith(
+          expect.objectContaining({ title: "My Form" })
+        )
+      })
+    })
+
+    it("shows error alert when API returns an error", async () => {
+      ;(global.fetch as any).mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: "Not authorized for this company" }),
+      })
+
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("Not authorized for this company")).toBeInTheDocument()
+      })
+    })
+
+    it("shows error alert when network request fails", async () => {
+      ;(global.fetch as any).mockRejectedValue(new Error("Network error"))
+
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument()
+      })
+    })
+
+    it("sends status=published when form is initialised as published", async () => {
+      const user = userEvent.setup()
+      const publishedForm: ApplicationForm = { ...existingForm, status: "published" }
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={publishedForm} />)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled()
+        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+        expect(body.status).toBe("published")
+      })
+    })
+
+    it("sends status=draft when toggle is off", async () => {
+      const user = userEvent.setup()
+      render(<ApplicationFormBuilderDialog {...defaultProps} initialForm={existingForm} />)
+
+      // Ensure toggle is off (form starts as draft)
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+        expect(body.status).toBe("draft")
+      })
+    })
+  })
+
+  describe("Cancel / close", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<ApplicationFormBuilderDialog {...defaultProps} onClose={onClose} />)
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }))
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/__tests__/JobApplicationFormDialog.test.tsx
+++ b/frontend/src/components/__tests__/JobApplicationFormDialog.test.tsx
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import JobApplicationFormDialog from "../JobApplicationFormDialog"
+import type { ApplicationForm } from "../../types/applicationForm"
+
+/* ---- Firebase mocks ---- */
+vi.mock("../../firebase", () => ({
+  db: {},
+  storage: {},
+}))
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  addDoc: vi.fn().mockResolvedValue({ id: "new-app-id" }),
+}))
+
+vi.mock("firebase/storage", () => ({
+  ref: vi.fn(),
+  uploadBytesResumable: vi.fn(),
+  getDownloadURL: vi.fn(),
+}))
+
+/* ---- helpers ---- */
+function makeForm(overrides?: Partial<ApplicationForm>): ApplicationForm {
+  return {
+    title: "Test Application Form",
+    description: "Please fill this out",
+    status: "published",
+    fields: [],
+    ...overrides,
+  }
+}
+
+const mockJob = {
+  id: "job-1",
+  companyId: "company-1",
+  name: "Software Engineer",
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  job: { ...mockJob, applicationForm: makeForm() },
+  studentId: "student-1",
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("JobApplicationFormDialog", () => {
+  describe("Guard conditions", () => {
+    it("renders nothing when form is null", () => {
+      const { container } = render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{ ...mockJob, applicationForm: null }}
+        />
+      )
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it("renders nothing when form status is draft", () => {
+      const { container } = render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{ ...mockJob, applicationForm: makeForm({ status: "draft" }) }}
+        />
+      )
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it("renders nothing when open is false", () => {
+      const { container } = render(
+        <JobApplicationFormDialog {...defaultProps} open={false} />
+      )
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe("Rendering", () => {
+    it("renders the form title in dialog header", () => {
+      render(<JobApplicationFormDialog {...defaultProps} />)
+      expect(screen.getByText("Test Application Form")).toBeInTheDocument()
+    })
+
+    it("renders the form description", () => {
+      render(<JobApplicationFormDialog {...defaultProps} />)
+      expect(screen.getByText("Please fill this out")).toBeInTheDocument()
+    })
+
+    it("renders Submit Application button", () => {
+      render(<JobApplicationFormDialog {...defaultProps} />)
+      expect(screen.getByRole("button", { name: /submit application/i })).toBeInTheDocument()
+    })
+
+    it("renders Close button", () => {
+      render(<JobApplicationFormDialog {...defaultProps} />)
+      expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument()
+    })
+  })
+
+  describe("Field label rendering", () => {
+    it("renders shortText field label as text above the input, not inside it", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Your name", required: false }],
+            }),
+          }}
+        />
+      )
+      // Label must appear as a Typography element separate from the input
+      expect(screen.getByText("Your name")).toBeInTheDocument()
+      // The input itself should NOT have a label prop (no floating MUI label)
+      const input = screen.getByRole("textbox")
+      expect(input).not.toHaveAttribute("id", expect.stringContaining("label"))
+    })
+
+    it("renders longText field label as text above the textarea", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "longText", label: "Describe yourself", required: false }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Describe yourself")).toBeInTheDocument()
+    })
+
+    it("shows required asterisk for required fields", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Full name", required: true }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Full name")).toBeInTheDocument()
+      expect(screen.getByText("*")).toBeInTheDocument()
+    })
+
+    it("does not show asterisk for non-required fields", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Optional note", required: false }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Optional note")).toBeInTheDocument()
+      expect(screen.queryByText("*")).not.toBeInTheDocument()
+    })
+
+    it("renders singleSelect field label above the select control", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [
+                { id: "f1", type: "singleSelect", label: "Experience level", required: false, options: ["Junior", "Senior"] },
+              ],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Experience level")).toBeInTheDocument()
+    })
+
+    it("renders multiSelect field label above the select control", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [
+                { id: "f1", type: "multiSelect", label: "Skills", required: false, options: ["React", "Node"] },
+              ],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Skills")).toBeInTheDocument()
+    })
+
+    it("renders checkbox field label above the checkbox", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "checkbox", label: "Agree to terms", required: false }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Agree to terms")).toBeInTheDocument()
+    })
+
+    it("renders file field label above the file input", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "file", label: "Upload resume", required: false }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByText("Upload resume")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /choose file/i })).toBeInTheDocument()
+    })
+  })
+
+  describe("Field interaction", () => {
+    it("updates shortText field value on input", async () => {
+      const user = userEvent.setup()
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Name", required: false }],
+            }),
+          }}
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await user.type(input, "Alice")
+      expect(input).toHaveValue("Alice")
+    })
+
+    it("updates longText field value on input", async () => {
+      const user = userEvent.setup()
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "longText", label: "Bio", required: false }],
+            }),
+          }}
+        />
+      )
+
+      const textarea = screen.getByRole("textbox")
+      await user.type(textarea, "Hello world")
+      expect(textarea).toHaveValue("Hello world")
+    })
+
+    it("toggles checkbox field on click", async () => {
+      const user = userEvent.setup()
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "checkbox", label: "I agree", required: false }],
+            }),
+          }}
+        />
+      )
+
+      const checkbox = screen.getByRole("checkbox")
+      expect(checkbox).not.toBeChecked()
+      await user.click(checkbox)
+      expect(checkbox).toBeChecked()
+    })
+  })
+
+  describe("Submit button state", () => {
+    it("disables Submit button when a required field is empty", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Name", required: true }],
+            }),
+          }}
+        />
+      )
+      expect(screen.getByRole("button", { name: /submit application/i })).toBeDisabled()
+    })
+
+    it("enables Submit button when all required fields are filled", async () => {
+      const user = userEvent.setup()
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{
+            ...mockJob,
+            applicationForm: makeForm({
+              fields: [{ id: "f1", type: "shortText", label: "Name", required: true }],
+            }),
+          }}
+        />
+      )
+
+      const input = screen.getByRole("textbox")
+      await user.type(input, "Alice")
+
+      expect(screen.getByRole("button", { name: /submit application/i })).toBeEnabled()
+    })
+
+    it("enables Submit button when there are no fields", () => {
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{ ...mockJob, applicationForm: makeForm({ fields: [] }) }}
+        />
+      )
+      expect(screen.getByRole("button", { name: /submit application/i })).toBeEnabled()
+    })
+  })
+
+  describe("Submission flow", () => {
+    it("shows success message after successful submission", async () => {
+      const user = userEvent.setup()
+      render(
+        <JobApplicationFormDialog
+          {...defaultProps}
+          job={{ ...mockJob, applicationForm: makeForm({ fields: [] }) }}
+        />
+      )
+
+      await user.click(screen.getByRole("button", { name: /submit application/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/application submitted successfully/i)).toBeInTheDocument()
+      })
+    })
+
+    it("calls onClose when Close is clicked", async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<JobApplicationFormDialog {...defaultProps} onClose={onClose} />)
+
+      await user.click(screen.getByRole("button", { name: /close/i }))
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/pages/BoothView.tsx
+++ b/frontend/src/pages/BoothView.tsx
@@ -29,6 +29,8 @@ import PhoneIcon from "@mui/icons-material/Phone"
 import LanguageIcon from "@mui/icons-material/Language"
 import LaunchIcon from "@mui/icons-material/Launch"
 import ProfileMenu from "./ProfileMenu"
+import JobApplicationFormDialog from "../components/JobApplicationFormDialog"
+import type { ApplicationForm } from "../types/applicationForm"
 import { API_URL } from "../config"
 import NotificationBell from "../components/NotificationBell"
 
@@ -58,6 +60,7 @@ interface Job {
   majorsAssociated: string
   applicationLink: string | null
   createdAt: number | null
+  applicationForm?: ApplicationForm | null
 }
 
 const INDUSTRY_LABELS: Record<string, string> = {
@@ -82,6 +85,8 @@ export default function BoothView() {
   const [loadingJobs, setLoadingJobs] = useState(false)
   const [error, setError] = useState("")
   const [startingChat, setStartingChat] = useState(false)
+  const [applyDialogOpen, setApplyDialogOpen] = useState(false)
+  const [selectedJobForApply, setSelectedJobForApply] = useState<Job | null>(null)
 
   // Track if component is mounted to prevent setState after unmount
   const isMountedRef = useRef(true)
@@ -450,7 +455,23 @@ export default function BoothView() {
                               <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a" }}>
                                 {job.name}
                               </Typography>
-                              {job.applicationLink && (
+                              {job.applicationForm && job.applicationForm.status === "published" ? (
+                                <Button
+                                  variant="contained"
+                                  onClick={() => {
+                                    setSelectedJobForApply(job)
+                                    setApplyDialogOpen(true)
+                                  }}
+                                  sx={{
+                                    background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+                                    "&:hover": {
+                                      background: "linear-gradient(135deg, #2d6b4d 0%, #388560 100%)",
+                                    },
+                                  }}
+                                >
+                                  Apply Now
+                                </Button>
+                              ) : job.applicationLink ? (
                                 <Button
                                   variant="contained"
                                   href={job.applicationLink}
@@ -465,7 +486,7 @@ export default function BoothView() {
                                 >
                                   Apply Now
                                 </Button>
-                              )}
+                              ) : null}
                             </Box>
                             <Typography variant="body2" color="text.secondary" sx={{ mb: 2, whiteSpace: "pre-wrap" }}>
                               {job.description}
@@ -657,6 +678,19 @@ export default function BoothView() {
           </Grid>
         </Grid>
       </Container>
+
+      {selectedJobForApply && (
+        <JobApplicationFormDialog
+          open={applyDialogOpen}
+          onClose={() => {
+            setApplyDialogOpen(false)
+            setSelectedJobForApply(null)
+          }}
+          job={selectedJobForApply}
+          boothId={booth?.id}
+          studentId={user?.role === "student" ? user.uid : null}
+        />
+      )}
     </Box>
   )
 }

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -1026,14 +1026,21 @@ export default function Company() {
                           </Box>
                           
                           {job.applicationForm && (
-                            <Box sx={{ mt: 1 }}>
+                            <Box sx={{ mt: 1, display: "flex", gap: 1, flexWrap: "wrap" }}>
                               <Chip
                                 icon={<DescriptionIcon sx={{ fontSize: 16 }} />}
-                                label="Application Form Available"
+                                label={
+                                  job.applicationForm.status === "published"
+                                    ? "Application Form: Published"
+                                    : "Application Form: Draft"
+                                }
                                 size="small"
                                 sx={{
-                                  bgcolor: "rgba(56, 133, 96, 0.08)",
-                                  color: "#388560",
+                                  bgcolor:
+                                    job.applicationForm.status === "published"
+                                      ? "rgba(56, 133, 96, 0.1)"
+                                      : "rgba(0, 0, 0, 0.04)",
+                                  color: job.applicationForm.status === "published" ? "#388560" : "text.secondary",
                                   fontWeight: 500,
                                 }}
                               />

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -35,10 +35,13 @@ import LaunchIcon from "@mui/icons-material/Launch"
 import SendIcon from "@mui/icons-material/Send"
 import BarChartIcon from "@mui/icons-material/BarChart"
 import DescriptionIcon from "@mui/icons-material/Description"
+import AssignmentIcon from "@mui/icons-material/Assignment"
+import DeleteSweepIcon from "@mui/icons-material/DeleteSweep"
 import ProfileMenu from "./ProfileMenu"
 import JobInviteDialog from "../components/JobInviteDialog"
 import JobInviteStatsDialog from "../components/JobInviteStatsDialog"
 import ApplicationFormBuilderDialog from "../components/ApplicationFormBuilderDialog"
+import SubmissionsViewerDialog from "../components/SubmissionsViewerDialog"
 import type { ApplicationForm } from "../types/applicationForm"
 import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
@@ -122,6 +125,10 @@ export default function Company() {
   const [selectedJobForStats, setSelectedJobForStats] = useState<Job | null>(null)
   const [applicationFormDialogOpen, setApplicationFormDialogOpen] = useState(false)
   const [selectedJobForForm, setSelectedJobForForm] = useState<Job | null>(null)
+  const [deleteFormDialogOpen, setDeleteFormDialogOpen] = useState(false)
+  const [jobToDeleteForm, setJobToDeleteForm] = useState<Job | null>(null)
+  const [deletingForm, setDeletingForm] = useState(false)
+  const [submissionsViewerOpen, setSubmissionsViewerOpen] = useState(false)
 
   const userId = useMemo(() => user?.uid, [user?.uid])
   const userRole = useMemo(() => user?.role, [user?.role])
@@ -312,6 +319,54 @@ export default function Company() {
   const handleManageApplicationFormClick = (job: Job) => {
     setSelectedJobForForm(job)
     setApplicationFormDialogOpen(true)
+  }
+
+  const handleDeleteFormClick = (job: Job) => {
+    setJobToDeleteForm(job)
+    setDeleteFormDialogOpen(true)
+  }
+
+  const handleDeleteFormConfirm = async () => {
+    if (!jobToDeleteForm) return
+
+    if (!auth.currentUser) {
+      setError("Your session has expired. Please log in again.")
+      setTimeout(() => navigate("/login"), 1500)
+      return
+    }
+
+    try {
+      setDeletingForm(true)
+      setError("")
+
+      const token = await auth.currentUser.getIdToken()
+      const response = await fetch(
+        `${API_URL}/api/jobs/${jobToDeleteForm.id}/form`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || "Failed to delete form.")
+      }
+
+      setJobs((prev) =>
+        prev.map((job) =>
+          job.id === jobToDeleteForm.id ? { ...job, applicationForm: undefined } : job
+        )
+      )
+      setSuccess("Application form deleted.")
+      setDeleteFormDialogOpen(false)
+      setJobToDeleteForm(null)
+    } catch (err: any) {
+      console.error("Error deleting form:", err)
+      setError(err?.message || "Failed to delete application form.")
+    } finally {
+      setDeletingForm(false)
+    }
   }
 
   const handleCreateJobClick = () => {
@@ -1066,6 +1121,28 @@ export default function Company() {
                                     <DescriptionIcon fontSize="small" />
                                   </IconButton>
                                 </Tooltip>
+                                {job.applicationForm && (
+                                  <Tooltip title="View submissions">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() => setSubmissionsViewerOpen(true)}
+                                      sx={{ color: "#388560" }}
+                                    >
+                                      <AssignmentIcon fontSize="small" />
+                                    </IconButton>
+                                  </Tooltip>
+                                )}
+                                {job.applicationForm && (
+                                  <Tooltip title="Delete application form">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() => handleDeleteFormClick(job)}
+                                      sx={{ color: "#d32f2f" }}
+                                    >
+                                      <DeleteSweepIcon fontSize="small" />
+                                    </IconButton>
+                                  </Tooltip>
+                                )}
                                 <Tooltip title="Delete job posting">
                                   <IconButton
                                     size="small"
@@ -1478,6 +1555,34 @@ export default function Company() {
               )
             )
           }}
+        />
+      )}
+
+      {/* Delete Application Form Confirmation Dialog */}
+      <Dialog open={deleteFormDialogOpen} onClose={() => { if (!deletingForm) { setDeleteFormDialogOpen(false); setJobToDeleteForm(null) } }}>
+        <DialogTitle>Delete Application Form</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete the application form for <strong>{jobToDeleteForm?.name}</strong>? This action cannot be undone and students will no longer be able to apply through this form.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => { setDeleteFormDialogOpen(false); setJobToDeleteForm(null) }} disabled={deletingForm}>
+            Cancel
+          </Button>
+          <Button onClick={handleDeleteFormConfirm} color="error" variant="contained" disabled={deletingForm}>
+            {deletingForm ? "Deleting..." : "Delete Form"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Submissions Viewer Dialog */}
+      {company && (
+        <SubmissionsViewerDialog
+          open={submissionsViewerOpen}
+          onClose={() => setSubmissionsViewerOpen(false)}
+          companyId={company.id}
+          jobs={jobs}
         />
       )}
     </Box>

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -41,7 +41,6 @@ import ProfileMenu from "./ProfileMenu"
 import JobInviteDialog from "../components/JobInviteDialog"
 import JobInviteStatsDialog from "../components/JobInviteStatsDialog"
 import ApplicationFormBuilderDialog from "../components/ApplicationFormBuilderDialog"
-import SubmissionsViewerDialog from "../components/SubmissionsViewerDialog"
 import type { ApplicationForm } from "../types/applicationForm"
 import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
@@ -128,7 +127,6 @@ export default function Company() {
   const [deleteFormDialogOpen, setDeleteFormDialogOpen] = useState(false)
   const [jobToDeleteForm, setJobToDeleteForm] = useState<Job | null>(null)
   const [deletingForm, setDeletingForm] = useState(false)
-  const [submissionsViewerOpen, setSubmissionsViewerOpen] = useState(false)
 
   const userId = useMemo(() => user?.uid, [user?.uid])
   const userRole = useMemo(() => user?.role, [user?.role])
@@ -1125,7 +1123,7 @@ export default function Company() {
                                   <Tooltip title="View submissions">
                                     <IconButton
                                       size="small"
-                                      onClick={() => setSubmissionsViewerOpen(true)}
+                                      onClick={() => navigate(`/company/${company?.id}/submissions`)}
                                       sx={{ color: "#388560" }}
                                     >
                                       <AssignmentIcon fontSize="small" />
@@ -1576,15 +1574,6 @@ export default function Company() {
         </DialogActions>
       </Dialog>
 
-      {/* Submissions Viewer Dialog */}
-      {company && (
-        <SubmissionsViewerDialog
-          open={submissionsViewerOpen}
-          onClose={() => setSubmissionsViewerOpen(false)}
-          companyId={company.id}
-          jobs={jobs}
-        />
-      )}
     </Box>
   )
 }

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -34,9 +34,12 @@ import AddIcon from "@mui/icons-material/Add"
 import LaunchIcon from "@mui/icons-material/Launch"
 import SendIcon from "@mui/icons-material/Send"
 import BarChartIcon from "@mui/icons-material/BarChart"
+import DescriptionIcon from "@mui/icons-material/Description"
 import ProfileMenu from "./ProfileMenu"
 import JobInviteDialog from "../components/JobInviteDialog"
 import JobInviteStatsDialog from "../components/JobInviteStatsDialog"
+import ApplicationFormBuilderDialog from "../components/ApplicationFormBuilderDialog"
+import type { ApplicationForm } from "../types/applicationForm"
 import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
 import ListItemText from "@mui/material/ListItemText"
@@ -70,6 +73,7 @@ interface Job {
   majorsAssociated: string
   applicationLink: string | null
   createdAt: number | null
+  applicationForm?: ApplicationForm
 }
 
 interface JobInvitationStats {
@@ -116,6 +120,8 @@ export default function Company() {
   const [deletingJob, setDeletingJob] = useState(false)
   const [statsDialogOpen, setStatsDialogOpen] = useState(false)
   const [selectedJobForStats, setSelectedJobForStats] = useState<Job | null>(null)
+  const [applicationFormDialogOpen, setApplicationFormDialogOpen] = useState(false)
+  const [selectedJobForForm, setSelectedJobForForm] = useState<Job | null>(null)
 
   const userId = useMemo(() => user?.uid, [user?.uid])
   const userRole = useMemo(() => user?.role, [user?.role])
@@ -220,7 +226,6 @@ export default function Company() {
   const fetchJobs = async (companyId: string) => {
     try {
       setLoadingJobs(true)
-      console.log("Fetching jobs for company:", companyId)
       
       const jobsRef = collection(db, "jobs")
       const q = query(jobsRef, where("companyId", "==", companyId))
@@ -229,6 +234,7 @@ export default function Company() {
       const jobsList: Job[] = []
       jobsSnapshot.forEach((doc) => {
         const data = doc.data()
+        const applicationFormData = data.applicationForm as ApplicationForm | undefined
         jobsList.push({
           id: doc.id,
           companyId: data.companyId,
@@ -237,6 +243,7 @@ export default function Company() {
           majorsAssociated: data.majorsAssociated,
           applicationLink: data.applicationLink || null,
           createdAt: data.createdAt?.toMillis?.() || data.createdAt || null,
+          applicationForm: applicationFormData
         })
       })
       
@@ -248,7 +255,6 @@ export default function Company() {
         return b.createdAt - a.createdAt
       })
       
-      console.log("Fetched jobs:", jobsList.length, "jobs")
       setJobs(jobsList)
       
       // Fetch stats for each job
@@ -301,6 +307,11 @@ export default function Company() {
   const handleViewStatsClick = (job: Job) => {
     setSelectedJobForStats(job)
     setStatsDialogOpen(true)
+  }
+
+  const handleManageApplicationFormClick = (job: Job) => {
+    setSelectedJobForForm(job)
+    setApplicationFormDialogOpen(true)
   }
 
   const handleCreateJobClick = () => {
@@ -384,7 +395,6 @@ export default function Company() {
         setJobDialogOpen(false)
       } else {
         // Create new job
-        console.log("Creating job for company:", company.id, company.companyName)
         
         const jobsRef = collection(db, "jobs")
         const jobData: any = {
@@ -993,6 +1003,15 @@ export default function Company() {
                                     <EditIcon fontSize="small" />
                                   </IconButton>
                                 </Tooltip>
+                                <Tooltip title={job.applicationForm ? "Edit application form" : "Create application form"}>
+                                  <IconButton
+                                    size="small"
+                                    onClick={() => handleManageApplicationFormClick(job)}
+                                    sx={{ color: job.applicationForm ? "#388560" : "text.secondary" }}
+                                  >
+                                    <DescriptionIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
                                 <Tooltip title="Delete job posting">
                                   <IconButton
                                     size="small"
@@ -1006,6 +1025,21 @@ export default function Company() {
                             </Box>
                           </Box>
                           
+                          {job.applicationForm && (
+                            <Box sx={{ mt: 1 }}>
+                              <Chip
+                                icon={<DescriptionIcon sx={{ fontSize: 16 }} />}
+                                label="Application Form Available"
+                                size="small"
+                                sx={{
+                                  bgcolor: "rgba(56, 133, 96, 0.08)",
+                                  color: "#388560",
+                                  fontWeight: 500,
+                                }}
+                              />
+                            </Box>
+                          )}
+
                           {/* Job Invitation Stats */}
                           {jobStats[job.id] && jobStats[job.id].totalSent > 0 && (
                             <Box 
@@ -1362,6 +1396,27 @@ export default function Company() {
           }}
           jobId={selectedJobForStats.id}
           jobTitle={selectedJobForStats.name}
+        />
+      )}
+
+      {/* Application Form Builder Dialog */}
+      {selectedJobForForm && (
+        <ApplicationFormBuilderDialog
+          open={applicationFormDialogOpen}
+          onClose={() => {
+            setApplicationFormDialogOpen(false)
+            setSelectedJobForForm(null)
+          }}
+          jobId={selectedJobForForm.id}
+          jobName={selectedJobForForm.name}
+          initialForm={selectedJobForForm.applicationForm}
+          onSaved={(updatedForm) => {
+            setJobs((prev) =>
+              prev.map((job) =>
+                job.id === selectedJobForForm.id ? { ...job, applicationForm: updatedForm } : job
+              )
+            )
+          }}
         />
       )}
     </Box>

--- a/frontend/src/pages/JobInvitations.tsx
+++ b/frontend/src/pages/JobInvitations.tsx
@@ -13,7 +13,6 @@ import {
   Tabs,
   Tab,
   IconButton,
-  Tooltip,
   Divider,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
@@ -22,9 +21,10 @@ import BusinessIcon from "@mui/icons-material/Business";
 import PersonIcon from "@mui/icons-material/Person";
 import LaunchIcon from "@mui/icons-material/Launch";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import VisibilityIcon from "@mui/icons-material/Visibility";
 import { authUtils } from "../utils/auth";
 import ProfileMenu from "./ProfileMenu";
+import JobApplicationFormDialog from "../components/JobApplicationFormDialog";
+import type { ApplicationForm } from "../types/applicationForm";
 
 interface JobInvitation {
   id: string;
@@ -40,10 +40,12 @@ interface JobInvitation {
   message?: string;
   job: {
     id: string;
+    companyId: string;
     name: string;
     description: string;
     majorsAssociated: string;
     applicationLink: string | null;
+    applicationForm?: ApplicationForm | null;
   } | null;
   company: {
     id: string;
@@ -66,6 +68,8 @@ export default function JobInvitations() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [currentTab, setCurrentTab] = useState<"all" | "sent" | "viewed" | "clicked">("all");
+  const [applyDialogOpen, setApplyDialogOpen] = useState(false);
+  const [selectedInvitationForApply, setSelectedInvitationForApply] = useState<JobInvitation | null>(null);
 
   useEffect(() => {
     
@@ -163,8 +167,13 @@ export default function JobInvitations() {
           )
         );
 
-        // Open application link if available
-        if (invitation.job?.applicationLink) {
+        const hasPublishedForm =
+          invitation.job?.applicationForm && invitation.job.applicationForm.status === "published";
+
+        if (hasPublishedForm) {
+          setSelectedInvitationForApply(invitation);
+          setApplyDialogOpen(true);
+        } else if (invitation.job?.applicationLink) {
           window.open(invitation.job.applicationLink, "_blank");
         }
       } catch (err) {
@@ -418,7 +427,8 @@ export default function JobInvitations() {
                     >
                       View Full Details
                     </Button>
-                    {invitation.job?.applicationLink && (
+                    {(invitation.job?.applicationLink ||
+                      invitation.job?.applicationForm?.status === "published") && (
                       <Button
                         variant="contained"
                         endIcon={<LaunchIcon />}
@@ -440,6 +450,19 @@ export default function JobInvitations() {
           </Box>
         )}
       </Container>
+
+      {selectedInvitationForApply && selectedInvitationForApply.job && (
+        <JobApplicationFormDialog
+          open={applyDialogOpen}
+          onClose={() => {
+            setApplyDialogOpen(false);
+            setSelectedInvitationForApply(null);
+          }}
+          job={selectedInvitationForApply.job}
+          boothId={selectedInvitationForApply.company?.boothId || undefined}
+          studentId={user?.uid || null}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/pages/SubmissionsPage.tsx
+++ b/frontend/src/pages/SubmissionsPage.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useState } from "react"
+import type React from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Container,
+  Divider,
+  IconButton,
+  Link,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material"
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"
+import AssignmentIcon from "@mui/icons-material/Assignment"
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
+import ExpandLessIcon from "@mui/icons-material/ExpandLess"
+import ChatIcon from "@mui/icons-material/Chat"
+import { auth, db } from "../firebase"
+import { doc, getDoc } from "firebase/firestore"
+import { authUtils } from "../utils/auth"
+import { API_URL } from "../config"
+import ProfileMenu from "./ProfileMenu"
+import type { ApplicationForm } from "../types/applicationForm"
+
+interface Submission {
+  id: string
+  jobId: string
+  companyId: string
+  studentId: string
+  responses: Record<string, string | string[] | boolean | null>
+  fileUrls?: Record<string, string>
+  submittedAt: number
+}
+
+interface Job {
+  id: string
+  name: string
+  applicationForm?: ApplicationForm
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleString()
+}
+
+function renderResponseValue(value: string | string[] | boolean | null): string {
+  if (value === null || value === undefined) return "—"
+  if (typeof value === "boolean") return value ? "Yes" : "No"
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "—"
+  return String(value) || "—"
+}
+
+function SubmissionCard({ submission, form, studentName }: { submission: Submission; form?: ApplicationForm; studentName?: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const navigate = useNavigate()
+
+  const handleChat = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    navigate("/dashboard/chat", { state: { repId: submission.studentId } })
+  }
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid rgba(56, 133, 96, 0.2)",
+        borderRadius: 1,
+        mb: 1,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 2,
+          py: 1.25,
+          cursor: "pointer",
+          bgcolor: "rgba(56, 133, 96, 0.04)",
+          "&:hover": { bgcolor: "rgba(56, 133, 96, 0.08)" },
+        }}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <Box>
+          {studentName && (
+            <Typography variant="body2" fontWeight={600} color="text.primary">
+              {studentName}
+            </Typography>
+          )}
+          <Typography variant="caption" color="text.secondary">
+            ID: {submission.studentId}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" display="block">
+            Submitted: {formatDate(submission.submittedAt)}
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <IconButton
+            size="small"
+            onClick={handleChat}
+            title="Chat with applicant"
+            sx={{ color: "#388560", mr: 0.5 }}
+          >
+            <ChatIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small">
+            {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Collapse in={expanded}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          {form && form.fields.length > 0 ? (
+            form.fields.map((field) => {
+              const value = submission.responses?.[field.id]
+              const fileUrl = submission.fileUrls?.[field.id]
+              return (
+                <Box key={field.id} sx={{ mb: 1.25 }}>
+                  <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                    {field.label}
+                    {field.required && (
+                      <Typography component="span" color="error" variant="caption">
+                        {" "}*
+                      </Typography>
+                    )}
+                  </Typography>
+                  {field.type === "file" ? (
+                    fileUrl ? (
+                      <Box>
+                        <Link href={fileUrl} target="_blank" rel="noopener noreferrer" variant="body2">
+                          View uploaded file
+                        </Link>
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No file uploaded
+                      </Typography>
+                    )
+                  ) : (
+                    <Typography variant="body2" color="text.primary" sx={{ mt: 0.25 }}>
+                      {renderResponseValue(value ?? null)}
+                    </Typography>
+                  )}
+                </Box>
+              )
+            })
+          ) : (
+            <Box>
+              {Object.entries(submission.responses ?? {}).map(([key, val]) => (
+                <Box key={key} sx={{ mb: 1 }}>
+                  <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                    {key}
+                  </Typography>
+                  <Typography variant="body2">{renderResponseValue(val)}</Typography>
+                </Box>
+              ))}
+              {submission.fileUrls &&
+                Object.entries(submission.fileUrls).map(([key, url]) => (
+                  <Box key={key} sx={{ mb: 1 }}>
+                    <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                      {key} (file)
+                    </Typography>
+                    <Box>
+                      <Link href={url} target="_blank" rel="noopener noreferrer" variant="body2">
+                        View uploaded file
+                      </Link>
+                    </Box>
+                  </Box>
+                ))}
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  )
+}
+
+export default function SubmissionsPage() {
+  const navigate = useNavigate()
+  const { companyId } = useParams<{ companyId: string }>()
+
+  const [submissions, setSubmissions] = useState<Submission[]>([])
+  const [jobs, setJobs] = useState<Job[]>([])
+  const [studentNames, setStudentNames] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [filterJobId, setFilterJobId] = useState<string>("all")
+
+  useEffect(() => {
+    if (!authUtils.isAuthenticated()) {
+      navigate("/login")
+      return
+    }
+    if (!companyId) return
+
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError("")
+
+        const token = await auth.currentUser?.getIdToken()
+        const headers = { Authorization: `Bearer ${token}` }
+
+        const [jobsRes, subsRes] = await Promise.all([
+          fetch(`${API_URL}/api/jobs?companyId=${companyId}`),
+          fetch(`${API_URL}/api/companies/${companyId}/submissions`, { headers }),
+        ])
+
+        if (!subsRes.ok) {
+          const data = await subsRes.json()
+          throw new Error(data.error || "Failed to load submissions.")
+        }
+
+        const jobsData = jobsRes.ok ? await jobsRes.json() : { jobs: [] }
+        const subsData = await subsRes.json()
+
+        const fetchedSubmissions: Submission[] = subsData.submissions ?? []
+        setJobs(jobsData.jobs ?? [])
+        setSubmissions(fetchedSubmissions)
+
+        // Batch-fetch names for all unique student IDs
+        const uniqueIds = [...new Set(fetchedSubmissions.map((s) => s.studentId))]
+        const nameEntries = await Promise.all(
+          uniqueIds.map(async (uid) => {
+            try {
+              const snap = await getDoc(doc(db, "users", uid))
+              if (!snap.exists()) return [uid, uid] as [string, string]
+              const d = snap.data()
+              const name =
+                d.firstName && d.lastName
+                  ? `${d.firstName} ${d.lastName}`
+                  : d.firstName || d.email || uid
+              return [uid, name] as [string, string]
+            } catch {
+              return [uid, uid] as [string, string]
+            }
+          })
+        )
+        setStudentNames(Object.fromEntries(nameEntries))
+      } catch (err: any) {
+        console.error("Error fetching submissions:", err)
+        setError(err?.message || "Failed to load submissions.")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [companyId, navigate])
+
+  const filteredSubmissions =
+    filterJobId === "all" ? submissions : submissions.filter((s) => s.jobId === filterJobId)
+
+  const jobMap = new Map(jobs.map((j) => [j.id, j]))
+
+  const grouped = filteredSubmissions.reduce<Record<string, Submission[]>>((acc, sub) => {
+    const key = sub.jobId
+    if (!acc[key]) acc[key] = []
+    acc[key].push(sub)
+    return acc
+  }, {})
+
+  return (
+    <Box sx={{ minHeight: "100vh", bgcolor: "#f5f5f5" }}>
+      {/* Header */}
+      <Box
+        sx={{
+          background: "linear-gradient(135deg, #b03a6c 0%, #388560 100%)",
+          py: 3,
+          px: 4,
+          boxShadow: "0 4px 20px rgba(0,0,0,0.3)",
+        }}
+      >
+        <Container maxWidth="lg">
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: 1 }}>
+              <IconButton onClick={() => navigate(`/company/${companyId}`)} sx={{ color: "white" }}>
+                <ArrowBackIcon />
+              </IconButton>
+              <AssignmentIcon sx={{ fontSize: 32, color: "white" }} />
+              <Typography variant="h4" sx={{ fontWeight: 700, color: "white" }}>
+                Application Submissions
+              </Typography>
+            </Box>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+              <ProfileMenu />
+            </Box>
+          </Box>
+        </Container>
+      </Box>
+
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {loading && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+            <CircularProgress sx={{ color: "#388560" }} />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {error}
+          </Alert>
+        )}
+
+        {!loading && !error && (
+          <>
+            {/* Filter */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                mb: 3,
+                p: 2,
+                bgcolor: "white",
+                borderRadius: 1,
+                border: "1px solid rgba(0,0,0,0.08)",
+              }}
+            >
+              <Typography variant="body2" color="text.secondary" flexShrink={0}>
+                Filter by job:
+              </Typography>
+              <Select
+                size="small"
+                value={filterJobId}
+                onChange={(e) => setFilterJobId(e.target.value)}
+                sx={{ minWidth: 220 }}
+              >
+                <MenuItem value="all">All jobs</MenuItem>
+                {jobs.map((j) => (
+                  <MenuItem key={j.id} value={j.id}>
+                    {j.name}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
+                {filteredSubmissions.length} submission{filteredSubmissions.length !== 1 ? "s" : ""}
+              </Typography>
+            </Box>
+
+            {filteredSubmissions.length === 0 ? (
+              <Box
+                sx={{
+                  textAlign: "center",
+                  py: 8,
+                  bgcolor: "white",
+                  borderRadius: 1,
+                  border: "1px solid rgba(0,0,0,0.08)",
+                }}
+              >
+                <AssignmentIcon sx={{ fontSize: 48, color: "text.disabled", mb: 1 }} />
+                <Typography color="text.secondary">No submissions yet.</Typography>
+                <Typography variant="caption" color="text.disabled" display="block" mt={0.5}>
+                  Publish an application form on a job to start receiving submissions.
+                </Typography>
+              </Box>
+            ) : (
+              Object.entries(grouped).map(([jobId, jobSubs]) => {
+                const job = jobMap.get(jobId)
+                return (
+                  <Box
+                    key={jobId}
+                    sx={{
+                      mb: 3,
+                      bgcolor: "white",
+                      borderRadius: 1,
+                      border: "1px solid rgba(0,0,0,0.08)",
+                      p: 2,
+                    }}
+                  >
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                      <Typography variant="subtitle1" fontWeight={700} color="#388560">
+                        {job?.name ?? jobId}
+                      </Typography>
+                      <Chip
+                        label={`${jobSubs.length} submission${jobSubs.length !== 1 ? "s" : ""}`}
+                        size="small"
+                      />
+                    </Box>
+                    <Divider sx={{ mb: 1.5 }} />
+                    {jobSubs.map((sub) => (
+                      <SubmissionCard
+                        key={sub.id}
+                        submission={sub}
+                        form={job?.applicationForm}
+                        studentName={studentNames[sub.studentId]}
+                      />
+                    ))}
+                  </Box>
+                )
+              })
+            )}
+          </>
+        )}
+      </Container>
+    </Box>
+  )
+}

--- a/frontend/src/pages/__tests__/Company.test.tsx
+++ b/frontend/src/pages/__tests__/Company.test.tsx
@@ -41,6 +41,11 @@ vi.mock("firebase/firestore", () => ({
 
 vi.mock("../../firebase", () => ({
   db: {},
+  auth: {
+    currentUser: {
+      getIdToken: vi.fn(() => Promise.resolve("mock-token")),
+    },
+  },
 }));
 
 // Import after mocks
@@ -922,6 +927,283 @@ describe("Company", () => {
         const statsText = screen.getByText(/Software Engineer/i).closest('div')?.textContent;
         // Stats should be visible somewhere in the job card
       }, { timeout: 5000 });
+    });
+  });
+
+  describe("Application Form Management", () => {
+    const mockJobWithForm = {
+      ...mockJobData,
+      applicationForm: {
+        title: "Apply Here",
+        status: "published",
+        fields: [{ id: "f1", type: "shortText", label: "Name", required: true }],
+      },
+    };
+
+    const mockJobWithDraftForm = {
+      ...mockJobData,
+      applicationForm: {
+        title: "Draft Form",
+        status: "draft",
+        fields: [],
+      },
+    };
+
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ totalSent: 0, totalViewed: 0, totalClicked: 0 }),
+      });
+    });
+
+    it("shows published application form chip on job card", async () => {
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      expect(
+        await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 })
+      ).toBeInTheDocument();
+    });
+
+    it("shows draft application form chip on job card", async () => {
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithDraftForm }),
+        empty: false,
+      });
+
+      renderComp();
+      expect(
+        await screen.findByText(/Application Form: Draft/i, {}, { timeout: 3000 })
+      ).toBeInTheDocument();
+    });
+
+    it("shows submissions navigation button when job has a form", async () => {
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const submissionIcons = screen.queryAllByTestId("AssignmentIcon");
+      expect(submissionIcons.length).toBeGreaterThan(0);
+    });
+
+    it("navigates to submissions page when submissions icon is clicked", async () => {
+      const user = userEvent.setup();
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const submissionIcons = screen.queryAllByTestId("AssignmentIcon");
+      if (submissionIcons.length > 0) {
+        await user.click(submissionIcons[0].closest("button")!);
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining("submissions"));
+      }
+    });
+
+    it("opens ApplicationFormBuilderDialog when manage form button is clicked", async () => {
+      const user = userEvent.setup();
+      renderComp();
+      await screen.findByText(/Software Engineer/i, {}, { timeout: 3000 });
+
+      const descIcons = screen.queryAllByTestId("DescriptionIcon");
+      if (descIcons.length > 0) {
+        await user.click(descIcons[0].closest("button")!);
+        expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      }
+    });
+
+    it("shows delete form button only when job has a form", async () => {
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      expect(deleteSweepIcons.length).toBeGreaterThan(0);
+    });
+
+    it("does not show delete form button when job has no form", async () => {
+      renderComp();
+      await screen.findByText(/Software Engineer/i, {}, { timeout: 3000 });
+
+      // Job has no applicationForm so DeleteSweepIcon should not be present
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      expect(deleteSweepIcons.length).toBe(0);
+    });
+
+    it("opens delete form confirmation dialog when delete form button is clicked", async () => {
+      const user = userEvent.setup();
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      if (deleteSweepIcons.length > 0) {
+        await user.click(deleteSweepIcons[0].closest("button")!);
+        expect(await screen.findByText(/Delete Application Form/i)).toBeInTheDocument();
+      }
+    });
+
+    it("cancels delete form dialog without calling API", async () => {
+      const user = userEvent.setup();
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      if (deleteSweepIcons.length > 0) {
+        await user.click(deleteSweepIcons[0].closest("button")!);
+        await screen.findByText(/Delete Application Form/i);
+
+        const cancelButtons = screen.queryAllByRole("button").filter(
+          (b) => b.textContent === "Cancel"
+        );
+        if (cancelButtons.length > 0) {
+          await user.click(cancelButtons[0]);
+          await waitFor(() => {
+            expect(screen.queryByText(/Delete Application Form/i)).not.toBeInTheDocument();
+          });
+        }
+      }
+
+      // API should not have been called for form deletion
+      const deleteCalls = (global.fetch as any).mock.calls.filter((call: any[]) =>
+        call[1]?.method === "DELETE"
+      );
+      expect(deleteCalls.length).toBe(0);
+    });
+
+    it("deletes application form and shows success message", async () => {
+      const user = userEvent.setup();
+
+      // First call returns stats (0), second call is the DELETE /api/jobs/:id/form
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ totalSent: 0, totalViewed: 0, totalClicked: 0 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        });
+
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      if (deleteSweepIcons.length > 0) {
+        await user.click(deleteSweepIcons[0].closest("button")!);
+        await screen.findByText(/Delete Application Form/i);
+
+        const deleteFormButtons = screen.queryAllByRole("button").filter(
+          (b) => b.textContent === "Delete Form"
+        );
+        if (deleteFormButtons.length > 0) {
+          await user.click(deleteFormButtons[0]);
+          expect(
+            await screen.findByText(/Application form deleted/i, {}, { timeout: 3000 })
+          ).toBeInTheDocument();
+        }
+      }
+    });
+
+    it("shows error when form deletion API call fails", async () => {
+      const user = userEvent.setup();
+
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ totalSent: 0, totalViewed: 0, totalClicked: 0 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ error: "Unauthorized to delete form" }),
+        });
+
+      (getDocs as any).mockResolvedValue({
+        forEach: (cb: any) => cb({ id: "job-1", data: () => mockJobWithForm }),
+        empty: false,
+      });
+
+      renderComp();
+      await screen.findByText(/Application Form: Published/i, {}, { timeout: 3000 });
+
+      const deleteSweepIcons = screen.queryAllByTestId("DeleteSweepIcon");
+      if (deleteSweepIcons.length > 0) {
+        await user.click(deleteSweepIcons[0].closest("button")!);
+        await screen.findByText(/Delete Application Form/i);
+
+        const deleteFormButtons = screen.queryAllByRole("button").filter(
+          (b) => b.textContent === "Delete Form"
+        );
+        if (deleteFormButtons.length > 0) {
+          await user.click(deleteFormButtons[0]);
+          expect(
+            await screen.findByText(/Unauthorized to delete form/i, {}, { timeout: 3000 })
+          ).toBeInTheDocument();
+        }
+      }
+    });
+  });
+
+  describe("Representative access control", () => {
+    beforeEach(() => {
+      (authUtils.getCurrentUser as any).mockReturnValue({
+        uid: "rep-1",
+        role: "representative",
+      });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ totalSent: 0, totalViewed: 0, totalClicked: 0 }),
+      });
+    });
+
+    it("hides invite code section from representatives", async () => {
+      renderComp();
+      await screen.findByRole('heading', { name: /Tech Corp/i }, { timeout: 3000 });
+
+      // Invite code is owner-only — rep should not see INVITE123
+      await waitFor(() => {
+        expect(screen.queryByText(/INVITE123/)).not.toBeInTheDocument();
+      });
+    });
+
+    it("hides delete company button from representatives", async () => {
+      renderComp();
+      await screen.findByRole('heading', { name: /Tech Corp/i }, { timeout: 3000 });
+
+      expect(screen.queryByRole("button", { name: /Delete Company/i })).not.toBeInTheDocument();
+    });
+
+    it("still displays job postings for representatives", async () => {
+      renderComp();
+      expect(await screen.findByText(/Software Engineer/i, {}, { timeout: 3000 })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/__tests__/SubmissionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SubmissionsPage.test.tsx
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import SubmissionsPage from "../SubmissionsPage"
+import { authUtils } from "../../utils/auth"
+
+/* ---- Router mocks ---- */
+const mockNavigate = vi.fn()
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom")
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ companyId: "company-1" }),
+  }
+})
+
+/* ---- Auth utils mock ---- */
+vi.mock("../../utils/auth", () => ({
+  authUtils: {
+    isAuthenticated: vi.fn(() => true),
+    getCurrentUser: vi.fn(() => ({ uid: "owner-1", email: "owner@test.com" })),
+  },
+}))
+
+/* ---- Firebase mock ---- */
+vi.mock("../../firebase", () => ({
+  auth: {
+    currentUser: { getIdToken: vi.fn().mockResolvedValue("mock-token") },
+  },
+  db: {},
+}))
+
+/* ---- Firestore mock (getDoc for student names) ---- */
+vi.mock("firebase/firestore", () => ({
+  doc: vi.fn(),
+  getDoc: vi.fn().mockResolvedValue({
+    exists: () => true,
+    data: () => ({ firstName: "Jane", lastName: "Doe", email: "jane@test.com" }),
+  }),
+}))
+
+/* ---- ProfileMenu mock ---- */
+vi.mock("../ProfileMenu", () => ({
+  default: () => <div data-testid="profile-menu" />,
+}))
+
+/* ---- fetch mock ---- */
+global.fetch = vi.fn()
+
+const mockJobs = [
+  {
+    id: "job-1",
+    name: "Software Engineer",
+    companyId: "company-1",
+    applicationForm: {
+      title: "SE Application",
+      status: "published",
+      fields: [
+        { id: "f1", type: "shortText", label: "Why do you want this role?", required: true },
+      ],
+    },
+  },
+]
+
+const mockSubmissions = [
+  {
+    id: "sub-1",
+    jobId: "job-1",
+    companyId: "company-1",
+    studentId: "student-1",
+    responses: { f1: "Because I love coding" },
+    submittedAt: 1700000000000,
+  },
+  {
+    id: "sub-2",
+    jobId: "job-1",
+    companyId: "company-1",
+    studentId: "student-2",
+    responses: { f1: "Great opportunity" },
+    submittedAt: 1700000001000,
+  },
+]
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/company/company-1/submissions"]}>
+      <Routes>
+        <Route path="/company/:companyId/submissions" element={<SubmissionsPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Ensure auth returns true for all tests unless explicitly overridden
+  vi.mocked(authUtils.isAuthenticated).mockReturnValue(true)
+  ;(global.fetch as any).mockImplementation((url: string) => {
+    if (url.includes("/api/jobs")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ jobs: mockJobs }) })
+    }
+    if (url.includes("/api/companies")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, submissions: mockSubmissions }) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+})
+
+describe("SubmissionsPage", () => {
+  describe("Authentication", () => {
+    it("redirects to /login when not authenticated", () => {
+      vi.mocked(authUtils.isAuthenticated).mockReturnValue(false)
+
+      renderPage()
+
+      expect(mockNavigate).toHaveBeenCalledWith("/login")
+    })
+  })
+
+  describe("Header", () => {
+    it("renders the page title", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText("Application Submissions")).toBeInTheDocument()
+      })
+    })
+
+    it("renders ProfileMenu", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-menu")).toBeInTheDocument()
+      })
+    })
+
+    it("back button navigates to company page", async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText("Application Submissions")).toBeInTheDocument()
+      })
+
+      // The back button is the first icon button in the header
+      const buttons = screen.getAllByRole("button")
+      await user.click(buttons[0])
+      expect(mockNavigate).toHaveBeenCalledWith("/company/company-1")
+    })
+  })
+
+  describe("Loading state", () => {
+    it("shows a loading spinner while fetching data", () => {
+      ;(global.fetch as any).mockReturnValue(new Promise(() => {}))
+      renderPage()
+      expect(screen.getByRole("progressbar")).toBeInTheDocument()
+    })
+  })
+
+  describe("Error state", () => {
+    it("shows error alert when submissions fetch fails", async () => {
+      ;(global.fetch as any).mockImplementation((url: string) => {
+        if (url.includes("/api/jobs")) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ jobs: [] }) })
+        }
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: "Unauthorized" }) })
+      })
+
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText("Unauthorized")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("Empty state", () => {
+    it("shows empty state message when no submissions exist", async () => {
+      ;(global.fetch as any).mockImplementation((url: string) => {
+        if (url.includes("/api/jobs")) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ jobs: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, submissions: [] }) })
+      })
+
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText("No submissions yet.")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("Submissions display", () => {
+    it("displays submissions count in the filter bar", async () => {
+      renderPage()
+      await waitFor(() => {
+        // Count appears both in the filter bar and in the job chip — use getAllByText
+        expect(screen.getAllByText("2 submissions").length).toBeGreaterThan(0)
+      })
+    })
+
+    it("shows student name resolved from Firestore", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getAllByText("Jane Doe").length).toBeGreaterThan(0)
+      })
+    })
+
+    it("groups submissions under the job name", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText("Software Engineer")).toBeInTheDocument()
+      })
+    })
+
+    it("shows submission count chip per job", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getAllByText("2 submissions").length).toBeGreaterThan(0)
+      })
+    })
+
+    it("expands a submission card to show response details", async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Jane Doe").length).toBeGreaterThan(0)
+      })
+
+      // Click the first expand button
+      const expandButtons = screen.getAllByRole("button", { name: "" })
+      const expandBtn = expandButtons.find((b) => b.querySelector("svg"))
+      if (expandBtn) {
+        await user.click(expandBtn)
+        await waitFor(() => {
+          expect(screen.getByText("Because I love coding")).toBeInTheDocument()
+        })
+      }
+    })
+  })
+
+  describe("Job filter", () => {
+    it("renders the job filter select", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText("All jobs")).toBeInTheDocument()
+      })
+    })
+
+    it("shows the job name as a filter option", async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText("Filter by job:")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("Chat navigation", () => {
+    it("chat button navigates to /dashboard/chat with studentId as repId", async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Jane Doe").length).toBeGreaterThan(0)
+      })
+
+      const chatButtons = screen.getAllByTitle("Chat with applicant")
+      await user.click(chatButtons[0])
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "/dashboard/chat",
+        expect.objectContaining({ state: expect.objectContaining({ repId: expect.any(String) }) })
+      )
+    })
+  })
+
+  describe("API calls", () => {
+    it("fetches jobs and submissions with the correct company ID", async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining("/api/jobs?companyId=company-1")
+        )
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining("/api/companies/company-1/submissions"),
+          expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer mock-token" }) })
+        )
+      })
+    })
+  })
+})

--- a/frontend/src/types/applicationForm.ts
+++ b/frontend/src/types/applicationForm.ts
@@ -3,7 +3,8 @@ export type FormFieldType =
   | "longText"
   | "singleSelect"
   | "multiSelect"
-  | "checkbox";
+  | "checkbox"
+  | "file";
 
 export interface FormField {
   id: string;

--- a/frontend/src/types/applicationForm.ts
+++ b/frontend/src/types/applicationForm.ts
@@ -1,0 +1,22 @@
+export type FormFieldType =
+  | "shortText"
+  | "longText"
+  | "singleSelect"
+  | "multiSelect"
+  | "checkbox";
+
+export interface FormField {
+  id: string;
+  type: FormFieldType;
+  label: string;
+  required: boolean;
+  options?: string[];
+}
+
+export interface ApplicationForm {
+  title: string;
+  description?: string;
+  fields: FormField[];
+  updatedAt?: number | null;
+}
+

--- a/frontend/src/types/applicationForm.ts
+++ b/frontend/src/types/applicationForm.ts
@@ -17,6 +17,9 @@ export interface ApplicationForm {
   title: string;
   description?: string;
   fields: FormField[];
+  status: "draft" | "published";
+  fairScheduleId?: string;
+  publishedAt?: number | null;
   updatedAt?: number | null;
 }
 


### PR DESCRIPTION
# PR: Custom In-App Job Application Forms

## What does this PR do?
Adds support for custom in-app job application forms. Companies can build forms with typed fields attached to a job listing, students fill them out at apply-time, and companies can review all submissions on a dedicated Submissions page.

## Changes
- Added `JobApplicationFormDialog.tsx` — student-facing apply dialog supporting text, textarea, checkbox, dropdown, and file-upload fields
- Added `ApplicationFormBuilderDialog.tsx` — company-side form builder for creating and editing custom application forms with typed fields
- Added `SubmissionsPage.tsx` — company view of all student submissions for a job, with expandable rows showing custom field responses
- Updated `Company.tsx` to integrate the form builder and link to the submissions page
- Added backend `applicationForms` endpoints for creating, fetching, and submitting forms
- Added Vitest tests for `ApplicationFormBuilderDialog`, `JobApplicationFormDialog`, and `SubmissionsPage`
- Added Jest tests for backend `applicationForms` endpoints (`__tests__/applicationForms.test.js`)

## How to Test
1. Log in as a company user, open a job listing, and use the form builder to add custom fields (e.g. text, dropdown, file upload), then save the form
2. Log in as a student, navigate to that job, click Apply, fill in the custom fields, and submit
3. Log back in as the company user and open the Submissions page for that job — verify the submission appears with all custom field responses visible

## Jira Issues
Closes #76

## Notes
<!-- Anything the reviewer should know (limitations, assumptions, etc.) -->