### PR TITLE
Bug/fix job invites

### DIFF
--- a/backend/__tests__/routes/companies.test.js
+++ b/backend/__tests__/routes/companies.test.js
@@ -281,7 +281,7 @@ describe("GET /api/companies/:companyId/invite-code", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 403 when user is not owner or admin", async () => {
+  it("returns 403 when user is not owner, representative, or admin", async () => {
     let callCount = 0;
     db.collection.mockImplementation(() => {
       callCount++;
@@ -305,6 +305,40 @@ describe("GET /api/companies/:companyId/invite-code", () => {
       .get("/api/companies/comp-1/invite-code")
       .set("Authorization", authHeader());
     expect(res.status).toBe(403);
+  });
+
+  it("returns invite code for company representative", async () => {
+    let callCount = 0;
+    db.collection.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                {
+                  ownerId: "other-uid",
+                  inviteCode: "REP123",
+                  representativeIDs: ["test-uid"],
+                },
+                true
+              )
+            ),
+          })),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue(mockDocSnap({ role: "representative" }, true)),
+        })),
+      };
+    });
+
+    const res = await request(app)
+      .get("/api/companies/comp-1/invite-code")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.inviteCode).toBe("REP123");
   });
 
   it("returns invite code for company owner", async () => {

--- a/backend/routes/companies.js
+++ b/backend/routes/companies.js
@@ -84,7 +84,7 @@ router.post("/link-company", verifyFirebaseToken, async (req, res) => {
 });
 
 /* ----------------------------------------------------
-   GET COMPANY INVITE CODE (owner or admin only)
+   GET COMPANY INVITE CODE (owner, representative, or admin)
 ---------------------------------------------------- */
 router.get("/companies/:companyId/invite-code", verifyFirebaseToken, async (req, res) => {
   try {
@@ -94,14 +94,18 @@ router.get("/companies/:companyId/invite-code", verifyFirebaseToken, async (req,
     const companyDoc = await db.collection("companies").doc(companyId).get();
     if (!companyDoc.exists) return res.status(404).json({ error: "Company not found" });
 
-    const { ownerId, inviteCode } = companyDoc.data();
+    const { ownerId, inviteCode, representativeIDs = [] } = companyDoc.data();
 
     const userDoc = await db.collection("users").doc(requestingUid).get();
     const isAdmin = userDoc.exists && userDoc.data().role === "administrator";
     const isOwner = ownerId === requestingUid;
+    const isRepresentative =
+      Array.isArray(representativeIDs) && representativeIDs.includes(requestingUid);
 
-    if (!isAdmin && !isOwner) {
-      return res.status(403).json({ error: "Only the company owner or an admin can view the invite code" });
+    if (!isAdmin && !isOwner && !isRepresentative) {
+      return res.status(403).json({
+        error: "Only the company owner, a representative of this company, or an admin can view the invite code",
+      });
     }
 
     if (!inviteCode) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:coverage:job-invitations": "vitest run --coverage src/components/__tests__/NotificationBell.test.tsx src/pages/__tests__/JobInvitations.test.tsx src/pages/__tests__/Dashboard.test.tsx src/components/__tests__/JobInviteDialog.test.tsx src/components/__tests__/JobInviteStatsDialog.test.tsx src/pages/__tests__/Company.test.tsx src/utils/__tests__/jobInvitationStatsFetch.test.ts --coverage.include=src/components/NotificationBell.tsx --coverage.include=src/pages/JobInvitations.tsx --coverage.include=src/pages/Dashboard.tsx --coverage.include=src/components/JobInviteDialog.tsx --coverage.include=src/components/JobInviteStatsDialog.tsx --coverage.include=src/utils/jobInvitationStatsFetch.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/frontend/src/components/JobInviteDialog.tsx
+++ b/frontend/src/components/JobInviteDialog.tsx
@@ -23,6 +23,7 @@ import {
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 import { authUtils } from "../utils/auth";
+import { API_URL } from "../config";
 
 interface Student {
   id: string;
@@ -127,13 +128,19 @@ export default function JobInviteDialog({
         params.append("boothId", boothId);
       }
 
-      const response = await fetch(
-        `http://localhost:5000/api/students?${params}`,
-        {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      const token = await authUtils.getIdToken();
+      if (!token) {
+        setError("Not authenticated");
+        return;
+      }
+
+      const response = await fetch(`${API_URL}/api/students?${params}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       if (response.ok) {
         const data = await response.json();
@@ -186,9 +193,17 @@ export default function JobInviteDialog({
         throw new Error("You must be logged in");
       }
 
-      const response = await fetch("http://localhost:5000/api/job-invitations/send", {
+      const token = await authUtils.getIdToken();
+      if (!token) {
+        throw new Error("Not authenticated");
+      }
+
+      const response = await fetch(`${API_URL}/api/job-invitations/send`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           jobId,
           studentIds: Array.from(selectedStudents),

--- a/frontend/src/components/JobInviteStatsDialog.tsx
+++ b/frontend/src/components/JobInviteStatsDialog.tsx
@@ -17,6 +17,7 @@ import {
   Divider,
 } from "@mui/material";
 import { authUtils } from "../utils/auth";
+import { API_URL } from "../config";
 import PersonIcon from "@mui/icons-material/Person";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import LaunchIcon from "@mui/icons-material/Launch";
@@ -79,11 +80,20 @@ export default function JobInviteStatsDialog({
       setLoading(true);
       setError("");
 
+      const token = await authUtils.getIdToken();
+      if (!token) {
+        setError("Not authenticated");
+        return;
+      }
+
       const response = await fetch(
-        `http://localhost:5000/api/job-invitations/details/${jobId}?userId=${user.uid}`,
+        `${API_URL}/api/job-invitations/details/${jobId}?userId=${user.uid}`,
         {
           method: "GET",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
         }
       );
 

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -61,11 +61,17 @@ export default function NotificationBell() {
     if (currentUser?.role !== "student") return;
 
     try {
+      const token = await authUtils.getIdToken();
+      if (!token) return;
+
       const response = await fetch(
         `${API_URL}/api/job-invitations/received?userId=${currentUser.uid}&status=sent`,
         {
           method: "GET",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
         }
       );
 

--- a/frontend/src/components/__tests__/JobInviteDialog.test.tsx
+++ b/frontend/src/components/__tests__/JobInviteDialog.test.tsx
@@ -7,7 +7,12 @@ import { authUtils } from "../../utils/auth";
 vi.mock("../../utils/auth", () => ({
   authUtils: {
     getCurrentUser: vi.fn(),
+    getIdToken: vi.fn(),
   },
+}));
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
 }));
 
 globalThis.fetch = vi.fn();
@@ -38,6 +43,7 @@ describe("JobInviteDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (authUtils.getCurrentUser as any).mockReturnValue(mockUser);
+    (authUtils.getIdToken as any).mockResolvedValue("mock-id-token");
     (globalThis.fetch as any).mockResolvedValue({
       ok: true,
       json: async () => ({ students: mockStudents }),
@@ -94,12 +100,17 @@ describe("JobInviteDialog", () => {
   // Fetch behaviour
   // -----------------------------------------------------------------------
 
-  it("fetches students with userId param", async () => {
+  it("fetches students with userId param and Bearer token", async () => {
     render(<JobInviteDialog {...defaultProps} />);
     await waitFor(() =>
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("userId=user-1"),
-        expect.any(Object)
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-id-token",
+          }),
+        })
       )
     );
   });
@@ -109,7 +120,11 @@ describe("JobInviteDialog", () => {
     await waitFor(() =>
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("boothId=booth-42"),
-        expect.any(Object)
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-id-token",
+          }),
+        })
       )
     );
   });
@@ -133,6 +148,13 @@ describe("JobInviteDialog", () => {
     render(<JobInviteDialog {...defaultProps} />);
     // Give time for any async effects to settle
     await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows Not authenticated when getIdToken returns null while loading students", async () => {
+    (authUtils.getIdToken as any).mockResolvedValue(null);
+    render(<JobInviteDialog {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText("Not authenticated")).toBeInTheDocument());
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -312,6 +334,9 @@ describe("JobInviteDialog", () => {
         "http://localhost:5000/api/job-invitations/send",
         expect.objectContaining({
           method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-id-token",
+          }),
           body: expect.stringContaining('"jobId":"job-1"'),
         })
       )
@@ -354,12 +379,57 @@ describe("JobInviteDialog", () => {
     );
   });
 
-  it("shows error when send request fails", async () => {
+  it("shows You must be logged in when getCurrentUser is null on send", async () => {
     const user = userEvent.setup();
 
     (globalThis.fetch as any)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ students: mockStudents }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: "Invite failed" }) });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ students: mockStudents }) });
+
+    render(<JobInviteDialog {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText("Alice Smith")).toBeInTheDocument());
+
+    await clickStudent(user, "Alice Smith");
+    (authUtils.getCurrentUser as any).mockReturnValue(null);
+    await user.click(screen.getByRole("button", { name: /Send \(1\)/i }));
+
+    await waitFor(() => expect(screen.getByText("You must be logged in")).toBeInTheDocument());
+  });
+
+  it("shows Not authenticated when getIdToken returns null on send", async () => {
+    const user = userEvent.setup();
+
+    (globalThis.fetch as any).mockImplementation((url: string) => {
+      if (String(url).includes("/api/students")) {
+        return Promise.resolve({ ok: true, json: async () => ({ students: mockStudents }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    (authUtils.getIdToken as any)
+      .mockResolvedValueOnce("mock-id-token")
+      .mockResolvedValue(null);
+
+    render(<JobInviteDialog {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText("Alice Smith")).toBeInTheDocument());
+
+    await clickStudent(user, "Alice Smith");
+    await user.click(screen.getByRole("button", { name: /Send \(1\)/i }));
+
+    await waitFor(() => expect(screen.getByText("Not authenticated")).toBeInTheDocument());
+  });
+
+  it("shows error when send request fails", async () => {
+    const user = userEvent.setup();
+
+    (globalThis.fetch as any).mockImplementation((url: string) => {
+      if (String(url).includes("/api/students")) {
+        return Promise.resolve({ ok: true, json: async () => ({ students: mockStudents }) });
+      }
+      if (String(url).includes("job-invitations/send")) {
+        return Promise.resolve({ ok: false, json: async () => ({ error: "Invite failed" }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
 
     render(<JobInviteDialog {...defaultProps} />);
     await waitFor(() => expect(screen.getByText("Alice Smith")).toBeInTheDocument());
@@ -373,9 +443,15 @@ describe("JobInviteDialog", () => {
   it("includes optional message in send payload when provided", async () => {
     const user = userEvent.setup();
 
-    (globalThis.fetch as any)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ students: mockStudents }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ sent: 1 }) });
+    (globalThis.fetch as any).mockImplementation((url: string) => {
+      if (String(url).includes("/api/students")) {
+        return Promise.resolve({ ok: true, json: async () => ({ students: mockStudents }) });
+      }
+      if (String(url).includes("job-invitations/send")) {
+        return Promise.resolve({ ok: true, json: async () => ({ sent: 1 }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
 
     render(<JobInviteDialog {...defaultProps} />);
     await waitFor(() => expect(screen.getByText("Alice Smith")).toBeInTheDocument());
@@ -386,7 +462,7 @@ describe("JobInviteDialog", () => {
 
     await waitFor(() =>
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.stringContaining("job-invitations/send"),
         expect.objectContaining({
           body: expect.stringContaining('"message":"Hello there!"'),
         })
@@ -435,9 +511,15 @@ describe("JobInviteDialog", () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
 
-    (globalThis.fetch as any)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ students: mockStudents }) })
-      .mockReturnValueOnce(new Promise(() => {})); // send call never resolves
+    (globalThis.fetch as any).mockImplementation((url: string) => {
+      if (String(url).includes("/api/students")) {
+        return Promise.resolve({ ok: true, json: async () => ({ students: mockStudents }) });
+      }
+      if (String(url).includes("job-invitations/send")) {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
 
     render(<JobInviteDialog {...defaultProps} onClose={onClose} />);
     await waitFor(() => expect(screen.getByText("Alice Smith")).toBeInTheDocument());
@@ -455,9 +537,14 @@ describe("JobInviteDialog", () => {
   // -----------------------------------------------------------------------
 
   it("dismisses error alert when close icon is clicked", async () => {
-    (globalThis.fetch as any).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Load failed" }),
+    (globalThis.fetch as any).mockImplementation((url: string) => {
+      if (String(url).includes("/api/students")) {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ error: "Load failed" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
     });
 
     const user = userEvent.setup();

--- a/frontend/src/components/__tests__/JobInviteStatsDialog.test.tsx
+++ b/frontend/src/components/__tests__/JobInviteStatsDialog.test.tsx
@@ -8,7 +8,12 @@ import { authUtils } from "../../utils/auth";
 vi.mock("../../utils/auth", () => ({
   authUtils: {
     getCurrentUser: vi.fn(),
+    getIdToken: vi.fn(),
   },
+}));
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
 }));
 
 // Mock fetch
@@ -72,6 +77,7 @@ describe("JobInviteStatsDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (authUtils.getCurrentUser as any).mockReturnValue(mockUser);
+    (authUtils.getIdToken as any).mockResolvedValue("mock-id-token");
     (globalThis.fetch as any).mockResolvedValue({
       ok: true,
       json: async () => ({ invitations: mockInvitations }),
@@ -118,6 +124,23 @@ describe("JobInviteStatsDialog", () => {
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
+  it("shows Not authenticated when getIdToken returns null", async () => {
+    (authUtils.getIdToken as any).mockResolvedValue(null);
+
+    render(
+      <JobInviteStatsDialog
+        open={true}
+        onClose={mockOnClose}
+        jobId="job-1"
+        jobTitle="Software Engineer"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Not authenticated")).toBeInTheDocument();
+    });
+  });
+
   it("fetches invitation details when opened", async () => {
     render(
       <JobInviteStatsDialog
@@ -133,7 +156,10 @@ describe("JobInviteStatsDialog", () => {
         "http://localhost:5000/api/job-invitations/details/job-1?userId=user-1",
         expect.objectContaining({
           method: "GET",
-          headers: { "Content-Type": "application/json" },
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Authorization: "Bearer mock-id-token",
+          }),
         })
       );
     });
@@ -475,6 +501,50 @@ describe("JobInviteStatsDialog", () => {
 
     await waitFor(() => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  it("formats sentAt older than 7 days as a locale date string", async () => {
+    const oldSent = new Date("2020-01-15T12:00:00.000Z").getTime();
+    const expectedDateLabel = new Date(oldSent).toLocaleDateString();
+    (globalThis.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        invitations: [
+          {
+            id: "inv-old",
+            studentId: "s1",
+            student: {
+              id: "s1",
+              firstName: "Test",
+              lastName: "User",
+              email: "test@test.com",
+              major: "CS",
+            },
+            status: "sent",
+            sentAt: oldSent,
+            viewedAt: null,
+            clickedAt: null,
+            message: null,
+          },
+        ],
+      }),
+    });
+
+    render(
+      <JobInviteStatsDialog
+        open={true}
+        onClose={mockOnClose}
+        jobId="job-1"
+        jobTitle="Software Engineer"
+      />
+    );
+
+    await waitFor(() => {
+      const sentLabels = screen.getAllByText((_content, node) =>
+        Boolean(node?.textContent?.includes(`Sent: ${expectedDateLabel}`))
+      );
+      expect(sentLabels.length).toBeGreaterThan(0);
     });
   });
 

--- a/frontend/src/components/__tests__/NotificationBell.test.tsx
+++ b/frontend/src/components/__tests__/NotificationBell.test.tsx
@@ -12,7 +12,10 @@ vi.mock("react-router-dom", async () => {
 })
 
 vi.mock("../../utils/auth", () => ({
-  authUtils: { getCurrentUser: vi.fn() },
+  authUtils: {
+    getCurrentUser: vi.fn(),
+    getIdToken: vi.fn(),
+  },
 }))
 
 vi.mock("../../config", () => ({
@@ -96,6 +99,7 @@ describe("NotificationBell", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue(studentUser)
+    vi.mocked(authUtils.authUtils.getIdToken).mockResolvedValue("mock-id-token")
     vi.mocked(studentUser.getIdToken).mockResolvedValue("mock-id-token")
     globalThis.fetch = vi.fn().mockImplementation(defaultFetchImpl)
   })
@@ -131,7 +135,12 @@ describe("NotificationBell", () => {
       await waitFor(() => {
         expect(globalThis.fetch).toHaveBeenCalledWith(
           expect.stringContaining("/api/job-invitations/received"),
-          expect.objectContaining({ method: "GET" })
+          expect.objectContaining({
+            method: "GET",
+            headers: expect.objectContaining({
+              Authorization: "Bearer mock-id-token",
+            }),
+          })
         )
       })
     })
@@ -188,8 +197,26 @@ describe("NotificationBell", () => {
       consoleError.mockRestore()
     })
 
-    it("skips video fetch when getIdToken returns falsy (lines 88-89)", async () => {
+    it("does not fetch job invitations when authUtils.getIdToken returns null", async () => {
+      vi.mocked(authUtils.authUtils.getIdToken).mockResolvedValue(null)
+      const fetchSpy = vi.fn().mockImplementation(defaultFetchImpl)
+      globalThis.fetch = fetchSpy
+      renderBell()
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          expect.stringContaining("/api/call-invitations/incoming"),
+          expect.any(Object)
+        )
+      })
+      const jobCalls = fetchSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("/api/job-invitations/received")
+      )
+      expect(jobCalls).toHaveLength(0)
+    })
+
+    it("skips video fetch when currentUser.getIdToken returns falsy", async () => {
       vi.mocked(studentUser.getIdToken).mockResolvedValue(undefined as unknown as string)
+      vi.mocked(authUtils.authUtils.getIdToken).mockResolvedValue("mock-id-token")
       const fetchSpy = vi.fn().mockImplementation(defaultFetchImpl)
       globalThis.fetch = fetchSpy
       renderBell()

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -3,6 +3,7 @@ import { getRepresentativeName } from "../utils/representativeUtils"
 import { useNavigate, useParams } from "react-router-dom"
 import { Container, Box, Typography, Button, Card, CardContent, Alert, CircularProgress, IconButton, Tooltip, Divider, Grid, TextField, Chip, Rating } from "@mui/material"
 import { authUtils } from "../utils/auth"
+import { fetchJobInvitationStats } from "../utils/jobInvitationStatsFetch"
 import { API_URL } from "../config"
 import { doc, getDoc, arrayRemove, updateDoc, collection, query, where, getDocs, addDoc, deleteDoc } from "firebase/firestore"
 import { db, auth } from "../firebase"
@@ -698,23 +699,11 @@ export default function Company() {
   }
 
   const fetchJobStats = async (jobId: string) => {
-    if (!userId) return
-
-    try {
-      const response = await fetch(
-        `${API_URL}/api/job-invitations/stats/${jobId}?userId=${userId}`,
-        {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        }
-      )
-
-      if (response.ok) {
-        const stats = await response.json()
-        setJobStats((prev) => ({ ...prev, [jobId]: stats }))
-      }
-    } catch (err) {
-      console.error(`Error fetching stats for job ${jobId}:`, err)
+    const result = await fetchJobInvitationStats<JobInvitationStats>(API_URL, jobId, userId || "", () =>
+      authUtils.getIdToken()
+    )
+    if (result.ok) {
+      setJobStats((prev) => ({ ...prev, [jobId]: result.stats }))
     }
   }
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -721,11 +721,17 @@ export default function Dashboard() {
 
     try {
       setLoadingInvitations(true);
+      const token = await authUtils.getIdToken();
+      if (!token) return;
+
       const response = await fetch(
         `${API_URL}/api/job-invitations/received?userId=${currentUser.uid}`,
         {
           method: "GET",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
         }
       );
 

--- a/frontend/src/pages/JobInvitations.tsx
+++ b/frontend/src/pages/JobInvitations.tsx
@@ -21,6 +21,7 @@ import LaunchIcon from "@mui/icons-material/Launch";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import EditIcon from "@mui/icons-material/Edit";
 import { authUtils } from "../utils/auth";
+import { API_URL } from "../config";
 import BaseLayout from "../components/BaseLayout";
 import JobApplicationFormDialog from "../components/JobApplicationFormDialog";
 import type { ApplicationForm } from "../types/applicationForm";
@@ -79,11 +80,19 @@ export default function JobInvitations() {
         setLoading(true);
         setError("");
 
+        const token = await authUtils.getIdToken();
+        if (!token) {
+          throw new Error("Not authenticated");
+        }
+
         const response = await fetch(
-          `http://localhost:5000/api/job-invitations/received?userId=${user.uid}`,
+          `${API_URL}/api/job-invitations/received?userId=${user.uid}`,
           {
             method: "GET",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
           }
         );
 
@@ -123,9 +132,15 @@ export default function JobInvitations() {
     // Mark as viewed if not already
     if (invitation.status === "sent" && user) {
       try {
-        await fetch(`http://localhost:5000/api/job-invitations/${invitation.id}/status`, {
+        const token = await authUtils.getIdToken();
+        if (!token) return;
+
+        await fetch(`${API_URL}/api/job-invitations/${invitation.id}/status`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({
             status: "viewed",
             userId: user.uid,
@@ -148,9 +163,15 @@ export default function JobInvitations() {
     // Mark as clicked
     if (user) {
       try {
-        await fetch(`http://localhost:5000/api/job-invitations/${invitation.id}/status`, {
+        const token = await authUtils.getIdToken();
+        if (!token) return;
+
+        await fetch(`${API_URL}/api/job-invitations/${invitation.id}/status`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({
             status: "clicked",
             userId: user.uid,

--- a/frontend/src/pages/__tests__/Company.test.tsx
+++ b/frontend/src/pages/__tests__/Company.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../utils/auth", () => ({
     isAuthenticated: vi.fn(() => true),
     deleteCompany: vi.fn(),
     updateInviteCode: vi.fn(),
+    getIdToken: vi.fn(() => Promise.resolve("mock-token")),
   },
 }));
 
@@ -846,6 +847,7 @@ describe("Company", () => {
 
   describe("Job Invitation Stats", () => {
     beforeEach(() => {
+      (authUtils.getIdToken as any).mockResolvedValue("mock-token");
       globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes("/ratings")) {
           return Promise.resolve({
@@ -854,6 +856,31 @@ describe("Company", () => {
           });
         }
         return Promise.resolve({ ok: false, json: async () => ({}) });
+      });
+    });
+
+    it("does not request job-invitations stats when getIdToken returns null", async () => {
+      (authUtils.getIdToken as any).mockResolvedValue(null);
+
+      const fetchSpy = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/ratings")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ ratings: [], totalRatings: 0, averageRating: null }),
+          });
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      });
+      globalThis.fetch = fetchSpy;
+
+      renderComp();
+      await screen.findByRole("heading", { name: /Tech Corp/i });
+
+      await waitFor(() => {
+        const statsCalls = fetchSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("/api/job-invitations/stats/")
+        );
+        expect(statsCalls).toHaveLength(0);
       });
     });
 
@@ -878,6 +905,58 @@ describe("Company", () => {
           expect.any(Object)
         );
       }, { timeout: 5000 });
+    });
+
+    it("ignores job invitation stats payload when response is not ok", async () => {
+      const fetchSpy = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/ratings")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ ratings: [], totalRatings: 0, averageRating: null }),
+          });
+        }
+        if (String(url).includes("/api/job-invitations/stats/")) {
+          return Promise.resolve({ ok: false, json: async () => ({ error: "forbidden" }) });
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      });
+      globalThis.fetch = fetchSpy;
+
+      renderComp();
+      await screen.findByRole("heading", { name: /Tech Corp/i });
+
+      await waitFor(() => {
+        const statsCalls = fetchSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("/api/job-invitations/stats/")
+        );
+        expect(statsCalls.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("still renders company when job invitation stats fetch throws", async () => {
+      const fetchSpy = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/ratings")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ ratings: [], totalRatings: 0, averageRating: null }),
+          });
+        }
+        if (String(url).includes("/api/job-invitations/stats/")) {
+          return Promise.reject(new Error("network down"));
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      });
+      globalThis.fetch = fetchSpy;
+
+      renderComp();
+      await screen.findByRole("heading", { name: /Tech Corp/i });
+
+      await waitFor(() => {
+        const statsCalls = fetchSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("/api/job-invitations/stats/")
+        );
+        expect(statsCalls.length).toBeGreaterThan(0);
+      });
     });
 
     it("displays View Details button when invitations exist", async () => {

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -10,6 +10,7 @@ const mockGetCurrentUser = vi.fn()
 const mockIsAuthenticated = vi.fn()
 const mockLinkRepresentativeToCompany = vi.fn()
 const mockParseMyResume = vi.fn().mockResolvedValue(undefined)
+const mockAuthGetIdToken = vi.hoisted(() => vi.fn().mockResolvedValue("mock-token"))
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom")
@@ -21,6 +22,7 @@ vi.mock("../../utils/auth", () => ({
     getCurrentUser: () => mockGetCurrentUser(),
     isAuthenticated: () => mockIsAuthenticated(),
     linkRepresentativeToCompany: (...args: any[]) => mockLinkRepresentativeToCompany(...args),
+    getIdToken: () => mockAuthGetIdToken(),
   },
   parseMyResume: () => mockParseMyResume(),
 }))
@@ -77,6 +79,7 @@ beforeEach(() => {
   mockIsAuthenticated.mockReturnValue(true)
   mockNavigate.mockClear()
   mockParseMyResume.mockResolvedValue(undefined)
+  mockAuthGetIdToken.mockResolvedValue("mock-token")
 
   // Mock getDocs for stats
   vi.mocked(firestore.getDocs).mockResolvedValue({
@@ -203,6 +206,39 @@ describe("Dashboard", () => {
 
       // Note: button is disabled when fair not live, so this just verifies it exists
       expect(screen.getByRole("button", { name: /browse all fairs/i })).toBeInTheDocument()
+    })
+
+    it("does not fetch job invitations when getIdToken returns null", async () => {
+      mockAuthGetIdToken.mockResolvedValue(null as unknown as string)
+      mockGetCurrentUser.mockReturnValue({
+        uid: "u1",
+        email: "student@test.com",
+        role: "student",
+      })
+      const fetchSpy = vi.fn().mockImplementation((input: string | Request | URL) => {
+        const url = getFetchUrl(input)
+        if (url.includes("/api/job-invitations/received")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ invitations: [] }),
+          }) as Promise<Response>
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) }) as Promise<Response>
+      })
+      globalThis.fetch = fetchSpy
+
+      render(
+        <MemoryRouter>
+          <Dashboard />
+        </MemoryRouter>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Job Invitations")).toBeInTheDocument()
+      })
+
+      const statsCalls = fetchSpy.mock.calls.filter((c) => getFetchUrl(c[0] as string).includes("/api/job-invitations/received"))
+      expect(statsCalls).toHaveLength(0)
     })
 
     it("displays Job Invitations card and navigates to job-invitations when View Invitations clicked", async () => {

--- a/frontend/src/pages/__tests__/JobInvitations.test.tsx
+++ b/frontend/src/pages/__tests__/JobInvitations.test.tsx
@@ -11,7 +11,12 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom")
   return { ...actual, useNavigate: () => mockNavigate }
 })
-vi.mock("../../utils/auth", () => ({ authUtils: { getCurrentUser: vi.fn() } }))
+vi.mock("../../utils/auth", () => ({
+  authUtils: {
+    getCurrentUser: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue("mock-token"),
+  },
+}))
 vi.mock("../ProfileMenu", () => ({ default: () => <div data-testid="profile-menu" /> }))
 vi.mock("../../components/NotificationBell", () => ({ default: () => <div data-testid="notification-bell" /> }))
 vi.mock("../../components/BaseLayout", () => ({
@@ -26,6 +31,18 @@ vi.mock("../../components/BaseLayout", () => ({
       {children}
     </div>
   ),
+}))
+
+vi.mock("../../components/JobApplicationFormDialog", () => ({
+  default: ({ open, onClose, job }: { open: boolean; onClose: () => void; job: { name?: string } }) =>
+    open ? (
+      <div data-testid="apply-form-dialog">
+        <span>Apply: {job?.name}</span>
+        <button type="button" onClick={onClose}>
+          Close apply dialog
+        </button>
+      </div>
+    ) : null,
 }))
 
 const mockInvitation = {
@@ -58,7 +75,19 @@ const renderJobInvitations = () =>
 describe("JobInvitations", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(authUtils.getIdToken).mockResolvedValue("mock-token")
     globalThis.fetch = vi.fn()
+  })
+
+  it("shows Not authenticated when getIdToken returns null", async () => {
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    vi.mocked(authUtils.getIdToken).mockResolvedValue(null)
+
+    renderJobInvitations()
+
+    await waitFor(() => {
+      expect(screen.getByText(/not authenticated/i)).toBeInTheDocument()
+    })
   })
 
   it("shows error for non-student users", () => {
@@ -114,6 +143,143 @@ describe("JobInvitations", () => {
     await waitFor(() => expect(screen.getByText("New")).toBeInTheDocument())
   })
 
+  it("truncates job description longer than 200 characters", async () => {
+    const longDesc = "x".repeat(250)
+    const inv = {
+      ...mockInvitation,
+      job: { ...mockInvitation.job, description: longDesc },
+    }
+
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [inv] }),
+    })
+
+    renderJobInvitations()
+
+    await waitFor(() => {
+      const truncated = screen.getByText((_, el) =>
+        Boolean(el?.textContent?.startsWith("x".repeat(200)) && el?.textContent?.endsWith("..."))
+      );
+      expect(truncated).toBeInTheDocument();
+    })
+  })
+
+  it("does not show Required Skills when majorsAssociated is empty", async () => {
+    const inv = {
+      ...mockInvitation,
+      job: { ...mockInvitation.job, majorsAssociated: "" },
+    }
+
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [inv] }),
+    })
+
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByText("Software Engineer")).toBeInTheDocument())
+
+    expect(screen.queryByText("Required Skills:")).not.toBeInTheDocument()
+  })
+
+  it("shows Representative when message exists but sender is null", async () => {
+    const inv = {
+      ...mockInvitation,
+      message: "Join us!",
+      sender: null as any,
+    }
+
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [inv] }),
+    })
+
+    renderJobInvitations()
+
+    await waitFor(() => {
+      expect(screen.getByText("Representative")).toBeInTheDocument()
+      expect(screen.getByText(/Join us!/)).toBeInTheDocument()
+    })
+  })
+
+  it("shows locale date when invitation was sent more than 7 days ago", async () => {
+    const oldSent = new Date("2019-06-01T12:00:00.000Z").getTime()
+    const expectedLabel = new Date(oldSent).toLocaleDateString()
+    const oldInv = { ...mockInvitation, sentAt: oldSent }
+
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [oldInv] }),
+    })
+
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByText(expectedLabel)).toBeInTheDocument())
+  })
+
+  it("navigates to tailor-simple when Tailor Resume is clicked", async () => {
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [mockInvitation] }),
+    })
+
+    const user = userEvent.setup()
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /tailor resume/i })).toBeInTheDocument())
+
+    await user.click(screen.getByRole("button", { name: /tailor resume/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith("/invitations/inv-1/tailor-simple")
+  })
+
+  it("opens apply dialog for published application form and closes it", async () => {
+    const invWithPublishedForm = {
+      ...mockInvitation,
+      company: { id: "c1", companyName: "Tech Corp", boothId: null },
+      job: {
+        ...mockInvitation.job,
+        applicationLink: null,
+        applicationForm: {
+          title: "Company form",
+          fields: [],
+          status: "published" as const,
+        },
+      },
+    }
+
+    vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ invitations: [invWithPublishedForm] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      })
+
+    const user = userEvent.setup()
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /apply now/i })).toBeInTheDocument())
+
+    await user.click(screen.getByRole("button", { name: /apply now/i }))
+
+    await waitFor(() => expect(screen.getByTestId("apply-form-dialog")).toBeInTheDocument())
+    expect(screen.getByText(/Apply: Software Engineer/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /close apply dialog/i }))
+
+    await waitFor(() => expect(screen.queryByTestId("apply-form-dialog")).not.toBeInTheDocument())
+  })
+
   it("shows empty state when no invitations", async () => {
     vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
     ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -166,6 +332,7 @@ describe("JobInvitations", () => {
 describe("JobInvitations — Apply Now button", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(authUtils.getIdToken).mockResolvedValue("mock-token")
     globalThis.fetch = vi.fn()
     vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
   })
@@ -212,6 +379,54 @@ describe("JobInvitations — Apply Now button", () => {
     })
   })
 
+  it("logs when PATCH for clicked status fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ invitations: [mockInvitation] }),
+      })
+      .mockRejectedValueOnce(new Error("patch failed"));
+
+    const user = userEvent.setup();
+    renderJobInvitations();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /apply now/i })).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /apply now/i }));
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith("Error updating invitation status:", expect.any(Error));
+    });
+
+    consoleError.mockRestore();
+  });
+
+  it("does not PATCH clicked status when getIdToken returns null after load", async () => {
+    vi.mocked(authUtils.getIdToken).mockResolvedValueOnce("mock-token").mockResolvedValueOnce(null)
+
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [mockInvitation] }),
+    })
+
+    const user = userEvent.setup()
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /apply now/i })).toBeInTheDocument())
+
+    const callsBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+
+    await user.click(screen.getByRole("button", { name: /apply now/i }))
+
+    const patchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: any[]) => call[1]?.method === "PATCH"
+    )
+    expect(patchCalls).toHaveLength(0)
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore)
+  })
+
   it("updates status chip to Applied after Apply Now", async () => {
     ;(globalThis.fetch as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce({
@@ -252,6 +467,7 @@ describe("JobInvitations — Apply Now button", () => {
 describe("JobInvitations — tab filtering", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(authUtils.getIdToken).mockResolvedValue("mock-token")
     globalThis.fetch = vi.fn()
     vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
   })
@@ -345,6 +561,7 @@ describe("JobInvitations — tab filtering", () => {
 describe("JobInvitations — handleViewJob error case", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(authUtils.getIdToken).mockResolvedValue("mock-token")
     globalThis.fetch = vi.fn()
     vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
   })
@@ -401,6 +618,56 @@ describe("JobInvitations — handleViewJob error case", () => {
     })
   })
 
+  it("logs when PATCH for viewed status fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ invitations: [mockInvitation] }),
+      })
+      .mockRejectedValueOnce(new Error("network error"));
+
+    const user = userEvent.setup();
+    renderJobInvitations();
+
+    await waitFor(() => expect(screen.getByText("Software Engineer")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /view full details/i }));
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith("Error updating invitation status:", expect.any(Error));
+    });
+
+    consoleError.mockRestore();
+  });
+
+  it("does not send PATCH when getIdToken returns null after load", async () => {
+    vi.mocked(authUtils.getIdToken).mockResolvedValueOnce("mock-token").mockResolvedValueOnce(null)
+
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invitations: [mockInvitation] }),
+    })
+
+    const user = userEvent.setup()
+    renderJobInvitations()
+
+    await waitFor(() => expect(screen.getByText("Software Engineer")).toBeInTheDocument())
+
+    const callsBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+
+    await user.click(screen.getByRole("button", { name: /view full details/i }))
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/booth/b1"))
+
+    const patchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: any[]) => call[1]?.method === "PATCH"
+    )
+    expect(patchCalls).toHaveLength(0)
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore)
+  })
+
   it("does not send PATCH when invitation status is already viewed", async () => {
     const viewedInvitation = { ...mockInvitation, status: "viewed" as const }
 
@@ -427,6 +694,7 @@ describe("JobInvitations — handleViewJob error case", () => {
 describe("JobInvitations — misc rendering", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(authUtils.getIdToken).mockResolvedValue("mock-token")
     globalThis.fetch = vi.fn()
     vi.mocked(authUtils.getCurrentUser).mockReturnValue({ uid: "student-1", role: "student" as const, email: "s@s.com" } as any)
   })

--- a/frontend/src/utils/__tests__/jobInvitationStatsFetch.test.ts
+++ b/frontend/src/utils/__tests__/jobInvitationStatsFetch.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchJobInvitationStats } from "../jobInvitationStatsFetch";
+
+describe("fetchJobInvitationStats", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok false when userId is empty", async () => {
+    const getIdToken = vi.fn();
+    const result = await fetchJobInvitationStats("http://api", "job-1", "", getIdToken);
+    expect(result).toEqual({ ok: false });
+    expect(getIdToken).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns ok false when getIdToken returns null", async () => {
+    const getIdToken = vi.fn().mockResolvedValue(null);
+    const result = await fetchJobInvitationStats("http://api", "job-1", "user-1", getIdToken);
+    expect(result).toEqual({ ok: false });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns ok false when response is not ok", async () => {
+    const getIdToken = vi.fn().mockResolvedValue("tok");
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "no" }),
+    } as Response);
+
+    const result = await fetchJobInvitationStats("http://api", "job-1", "user-1", getIdToken);
+
+    expect(result).toEqual({ ok: false });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://api/api/job-invitations/stats/job-1?userId=user-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer tok",
+        }),
+      })
+    );
+  });
+
+  it("returns stats when response is ok", async () => {
+    const payload = { totalSent: 1, totalViewed: 0, totalClicked: 0 };
+    const getIdToken = vi.fn().mockResolvedValue("tok");
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    const result = await fetchJobInvitationStats("http://api", "job-9", "rep-1", getIdToken);
+
+    expect(result).toEqual({ ok: true, stats: payload });
+  });
+
+  it("returns ok false when fetch throws", async () => {
+    const getIdToken = vi.fn().mockResolvedValue("tok");
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("network"));
+
+    const result = await fetchJobInvitationStats("http://api", "job-1", "user-1", getIdToken);
+
+    expect(result).toEqual({ ok: false });
+  });
+});

--- a/frontend/src/utils/jobInvitationStatsFetch.ts
+++ b/frontend/src/utils/jobInvitationStatsFetch.ts
@@ -1,0 +1,40 @@
+/**
+ * Fetches per-job invitation stats for the company jobs list (authenticated).
+ */
+export async function fetchJobInvitationStats<T>(
+  apiUrl: string,
+  jobId: string,
+  userId: string,
+  getIdToken: () => Promise<string | null>
+): Promise<{ ok: true; stats: T } | { ok: false }> {
+  if (!userId) {
+    return { ok: false };
+  }
+
+  try {
+    const token = await getIdToken();
+    if (!token) {
+      return { ok: false };
+    }
+
+    const response = await fetch(
+      `${apiUrl}/api/job-invitations/stats/${jobId}?userId=${userId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return { ok: false };
+    }
+
+    const stats = (await response.json()) as T;
+    return { ok: true, stats };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         'node_modules/',
         'src/test/',
         '**/*.css',
-      ]
+      ],
     }
   },
 })


### PR DESCRIPTION
# PR: Job invitations: auth headers, rep invite-code access, and test fixes

## What does this PR does?
Employer-facing job invitation flows now send a Firebase ID token on API calls, and company representatives can load the booth invite code the same way owners can. Frontend tests were updated so mocks match the new `getIdToken` + `fetch` behavior (URL-based `fetch` mocks where order-sensitive `mockResolvedValueOnce` chains broke).

## Changes
- Add `Authorization: Bearer <token>` and consistent `API_URL` usage for job-invitation related fetches (e.g. students list, send, stats, notifications) where they were missing or hardcoded.
- Backend: allow `GET /api/companies/:companyId/invite-code` for users listed in `representativeIDs`, not only owner/admin.
- Extract or reuse small helpers where helpful (e.g. shared stats fetch) and add/adjust unit tests, including `JobInviteDialog` tests using `mockImplementation` by URL.

## How to Test
1. Log in as a **company representative** (not only owner), open the company page, open the job invitation dialog: students load without 401; invite code request returns 200, not 403.
2. Run frontend tests: `npx vitest run src/components/__tests__/JobInviteDialog.test.tsx` (and optionally `npm run test:coverage:job-invitations` if present).
3. Smoke: send an invitation from the dialog and confirm the student sees it on their side (dashboard / notifications as designed).

## Notes
Reviewers should confirm no other callers still omit the Bearer token for protected `/api/students` or company invite-code routes. If Jira uses a different “Closes” format (e.g. `ABC-123`), replace the line above accordingly.