### PR TITLE
Admin Fair Announcements

### DIFF
--- a/backend/__tests__/fairs.helpers.unit.test.js
+++ b/backend/__tests__/fairs.helpers.unit.test.js
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for fairs.js helpers exposed as router.testHelpers in NODE_ENV=test.
+ */
+jest.mock("../firebase", () => ({
+  db: { collection: jest.fn() },
+  auth: {},
+}));
+
+const fairsRouter = require("../routes/fairs");
+
+describe("fairScheduleFromFairData", () => {
+  const { fairScheduleFromFairData } = fairsRouter.testHelpers;
+
+  it("returns {} when fairData is null or undefined", () => {
+    expect(fairScheduleFromFairData(null)).toEqual({});
+    expect(fairScheduleFromFairData(undefined)).toEqual({});
+  });
+
+  it("returns null millis when start/end timestamps are missing", () => {
+    expect(fairScheduleFromFairData({})).toEqual({
+      fairStartTime: null,
+      fairEndTime: null,
+    });
+  });
+
+  it("maps startTime and endTime via toMillis when present", () => {
+    expect(
+      fairScheduleFromFairData({
+        startTime: { toMillis: () => 111 },
+        endTime: { toMillis: () => 222 },
+      }),
+    ).toEqual({ fairStartTime: 111, fairEndTime: 222 });
+  });
+});
+
+describe("serializeAnnouncementDoc", () => {
+  const { serializeAnnouncementDoc } = fairsRouter.testHelpers;
+
+  it("treats non-object fairSchedule like {}", () => {
+    const doc = {
+      id: "ann-1",
+      data: () => ({
+        title: null,
+        description: undefined,
+        published: 0,
+        createdBy: undefined,
+      }),
+    };
+    const out = serializeAnnouncementDoc(doc, "fair-x", null, "not-an-object");
+    expect(out.fairStartTime).toBeNull();
+    expect(out.fairEndTime).toBeNull();
+    expect(out.title).toBe("");
+    expect(out.description).toBe("");
+    expect(out.published).toBe(false);
+    expect(out.createdBy).toBeNull();
+  });
+
+  it("merges fairSchedule object and normalizes announcement fields", () => {
+    const doc = {
+      id: "ann-2",
+      data: () => ({
+        title: "  Hello  ",
+        description: "  World  ",
+        published: true,
+        publishedAt: { toMillis: () => 10 },
+        createdAt: { toMillis: () => 20 },
+        updatedAt: { toMillis: () => 30 },
+        createdBy: "uid-1",
+      }),
+    };
+    const out = serializeAnnouncementDoc(doc, "fair-y", "Fair Y", {
+      fairStartTime: 1,
+      fairEndTime: 2,
+    });
+    expect(out.id).toBe("ann-2");
+    expect(out.fairId).toBe("fair-y");
+    expect(out.fairName).toBe("Fair Y");
+    expect(out.title).toBe("Hello");
+    expect(out.description).toBe("World");
+    expect(out.published).toBe(true);
+    expect(out.publishedAt).toBe(10);
+    expect(out.createdAt).toBe(20);
+    expect(out.updatedAt).toBe(30);
+    expect(out.createdBy).toBe("uid-1");
+    expect(out.fairStartTime).toBe(1);
+    expect(out.fairEndTime).toBe(2);
+  });
+});

--- a/backend/__tests__/fairs2.test.js
+++ b/backend/__tests__/fairs2.test.js
@@ -595,6 +595,230 @@ describe("GET /api/fairs/my-enrollments", () => {
     expect(res.status).toBe(200);
     expect(res.body.enrollments).toEqual([]);
   });
+
+  it("for companyOwner with no profile companyId, aggregates enrollments from owned companies query", async () => {
+    const batchMock = {
+      set: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+    db.batch.mockReturnValue(batchMock);
+
+    const enrollDocOwned = {
+      exists: true,
+      data: () => ({
+        boothId: "booth-owned",
+        enrolledAt: { toMillis: () => 111 },
+      }),
+    };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ uid: "owner-only", role: "companyOwner" }, true, "owner-only"),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(
+            mockQuerySnap([{ id: "owned-co-1", data: () => ({ ownerId: "owner-only" }) }]),
+          ),
+        };
+      }
+      if (name === "fairs") {
+        const enrollmentSubcol = {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(enrollDocOwned),
+          })),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+        const fairDocRef = {
+          get: jest.fn().mockResolvedValue(mockDocSnap(FAIR_DATA, true, "fair-id")),
+          id: "fair-id",
+          collection: jest.fn(() => enrollmentSubcol),
+        };
+        return {
+          doc: jest.fn(() => fairDocRef),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([{ id: "fair-id", data: () => FAIR_DATA }])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+    });
+
+    auth.verifyIdToken.mockResolvedValue({ uid: "owner-only", email: "o@test.com" });
+
+    const res = await request(app)
+      .get("/api/fairs/my-enrollments")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.enrollments).toHaveLength(1);
+    expect(res.body.enrollments[0].companyId).toBe("owned-co-1");
+    expect(res.body.enrollments[0].boothId).toBe("booth-owned");
+  });
+
+  it("for representative, uses profile companyId after representative branch (clear + single id)", async () => {
+    const batchMock = {
+      set: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+    db.batch.mockReturnValue(batchMock);
+
+    const enrollDoc = {
+      exists: true,
+      data: () => ({
+        boothId: "booth-rep",
+        enrolledAt: { toMillis: () => 222 },
+      }),
+    };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                { uid: "rep-uid", role: "representative", companyId: "rep-company" },
+                true,
+                "rep-uid",
+              ),
+            ),
+          })),
+        };
+      }
+      if (name === "fairs") {
+        const enrollmentSubcol = {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(enrollDoc),
+          })),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+        const fairDocRef = {
+          get: jest.fn().mockResolvedValue(mockDocSnap(FAIR_DATA, true, "fair-id")),
+          id: "fair-id",
+          collection: jest.fn(() => enrollmentSubcol),
+        };
+        return {
+          doc: jest.fn(() => fairDocRef),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([{ id: "fair-id", data: () => FAIR_DATA }])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+    });
+
+    auth.verifyIdToken.mockResolvedValue({ uid: "rep-uid", email: "rep@test.com" });
+
+    const res = await request(app)
+      .get("/api/fairs/my-enrollments")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.enrollments).toHaveLength(1);
+    expect(res.body.enrollments[0].companyId).toBe("rep-company");
+  });
+
+  it("for companyOwner with profile and owned companies, returns multiple enrollments when multiple ids are enrolled", async () => {
+    const batchMock = {
+      set: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+    db.batch.mockReturnValue(batchMock);
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                { uid: "multi-owner", role: "companyOwner", companyId: "co-a" },
+                true,
+                "multi-owner",
+              ),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(
+            mockQuerySnap([{ id: "co-b", data: () => ({ ownerId: "multi-owner" }) }]),
+          ),
+        };
+      }
+      if (name === "fairs") {
+        const enrollmentSubcol = {
+          doc: jest.fn((cid) => ({
+            get: jest.fn().mockResolvedValue(
+              cid === "co-a"
+                ? mockDocSnap({ boothId: "ba", enrolledAt: { toMillis: () => 1 } }, true, "co-a")
+                : cid === "co-b"
+                  ? mockDocSnap({ boothId: "bb", enrolledAt: { toMillis: () => 2 } }, true, "co-b")
+                  : mockDocSnap(null, false),
+            ),
+          })),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+        const fairDocRef = {
+          get: jest.fn().mockResolvedValue(mockDocSnap(FAIR_DATA, true, "fair-id")),
+          id: "fair-id",
+          collection: jest.fn(() => enrollmentSubcol),
+        };
+        return {
+          doc: jest.fn(() => fairDocRef),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([{ id: "fair-id", data: () => FAIR_DATA }])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+    });
+
+    auth.verifyIdToken.mockResolvedValue({ uid: "multi-owner", email: "m@test.com" });
+
+    const res = await request(app)
+      .get("/api/fairs/my-enrollments")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.enrollments).toHaveLength(2);
+    const ids = res.body.enrollments.map((e) => e.companyId).sort();
+    expect(ids).toEqual(["co-a", "co-b"]);
+  });
 });
 
 /* =======================================================

--- a/backend/__tests__/fairs2.test.js
+++ b/backend/__tests__/fairs2.test.js
@@ -128,6 +128,9 @@ function setupFairsDbMock({
   boothDocs = [],
   jobDocs = [],
   enrollmentDocs = [],
+  announcementListDocs = [],
+  announcementDocForPutDelete = null,
+  announcementPutDeleteExists = true,
 } = {}) {
   const batchMock = {
     set: jest.fn().mockReturnThis(),
@@ -160,6 +163,50 @@ function setupFairsDbMock({
         newDocId: "company-id",
       });
 
+      const annDataForNew = {
+        title: "Posted title",
+        description: "New session",
+        published: true,
+        publishedAt: { toMillis: () => 1000000 },
+        createdAt: { toMillis: () => 1000000 },
+        updatedAt: { toMillis: () => 1000000 },
+        createdBy: "admin-uid",
+      };
+      let announcementMutable = announcementDocForPutDelete
+        ? { ...announcementDocForPutDelete }
+        : { ...annDataForNew };
+      const announcementSubcol = {
+        doc: jest.fn((annId) => ({
+          get: jest.fn().mockImplementation(() =>
+            Promise.resolve(
+              mockDocSnap(
+                announcementMutable,
+                announcementPutDeleteExists,
+                annId || "ann-id",
+              ),
+            ),
+          ),
+          update: jest.fn().mockImplementation((patch) => {
+            announcementMutable = {
+              ...announcementMutable,
+              ...patch,
+              title: patch.title ?? announcementMutable.title,
+              description: patch.description ?? announcementMutable.description,
+              published: patch.published ?? announcementMutable.published,
+              publishedAt: patch.publishedAt ?? announcementMutable.publishedAt,
+            };
+          }),
+          delete: jest.fn().mockResolvedValue(undefined),
+        })),
+        add: jest.fn().mockResolvedValue({
+          id: "new-announcement-id",
+          get: jest.fn().mockResolvedValue(mockDocSnap(annDataForNew, true, "new-announcement-id")),
+        }),
+        get: jest.fn().mockResolvedValue(mockQuerySnap(announcementListDocs)),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+
       const fairDocRef = {
         get: jest.fn().mockResolvedValue(mockDocSnap(fairData, fairExists, fairId)),
         set: jest.fn().mockResolvedValue(undefined),
@@ -172,6 +219,7 @@ function setupFairsDbMock({
           if (sub === "booths") return boothSubcol.subColRef;
           if (sub === "jobs") return jobSubcol.subColRef;
           if (sub === "enrollments") return enrollmentSubcol.subColRef;
+          if (sub === "announcements") return announcementSubcol;
           return makeSubcollectionMock().subColRef;
         }),
       };
@@ -482,6 +530,7 @@ describe("GET /api/fairs/my-enrollments", () => {
     expect(res.status).toBe(200);
     expect(res.body.enrollments).toHaveLength(1);
     expect(res.body.enrollments[0].fairId).toBe("fair-id");
+    expect(res.body.enrollments[0].companyId).toBe("company-id");
     expect(res.body.enrollments[0].boothId).toBe("booth-abc");
   });
 
@@ -545,6 +594,241 @@ describe("GET /api/fairs/my-enrollments", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.enrollments).toEqual([]);
+  });
+});
+
+/* =======================================================
+   GET /api/fairs/my-announcements
+======================================================= */
+describe("GET /api/fairs/my-announcements", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app).get("/api/fairs/my-announcements");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty announcements for non-company roles", async () => {
+    setupFairsDbMock({
+      userData: { uid: "admin-uid", role: "student" },
+      userExists: true,
+    });
+    const res = await request(app)
+      .get("/api/fairs/my-announcements")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.announcements).toEqual([]);
+  });
+
+  it("returns published announcements for enrolled company representative", async () => {
+    const enrollDoc = {
+      exists: true,
+      data: () => ({
+        boothId: "booth-abc",
+        enrolledAt: { toMillis: () => 999999 },
+      }),
+    };
+
+    const annDoc = {
+      id: "ann-1",
+      data: () => ({
+        title: "Reminder",
+        description: "Q&A at noon",
+        published: true,
+        publishedAt: { toMillis: () => 100 },
+        createdAt: { toMillis: () => 5000 },
+        updatedAt: { toMillis: () => 5000 },
+      }),
+    };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                { uid: "rep-uid", companyId: "company-id", role: "representative" },
+                true,
+                "rep-uid",
+              ),
+            ),
+          })),
+        };
+      }
+      if (name === "fairs") {
+        const enrollmentSubcol = {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(enrollDoc),
+          })),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+        const announcementSubcol = {
+          doc: jest.fn(() => ({ get: jest.fn(), update: jest.fn(), delete: jest.fn() })),
+          add: jest.fn(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([annDoc])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+
+        const fairDocRef = {
+          get: jest.fn().mockResolvedValue(mockDocSnap(FAIR_DATA, true, "fair-id")),
+          id: "fair-id",
+          collection: jest.fn((sub) => {
+            if (sub === "enrollments") return enrollmentSubcol;
+            if (sub === "announcements") return announcementSubcol;
+            return makeSubcollectionMock().subColRef;
+          }),
+        };
+
+        return {
+          doc: jest.fn(() => fairDocRef),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([{ id: "fair-id", data: () => FAIR_DATA }])),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+      };
+    });
+
+    auth.verifyIdToken.mockResolvedValue({ uid: "rep-uid", email: "rep@test.com" });
+
+    const res = await request(app)
+      .get("/api/fairs/my-announcements")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.announcements).toHaveLength(1);
+    expect(res.body.announcements[0].fairId).toBe("fair-id");
+    expect(res.body.announcements[0].fairName).toBe("Spring Fair");
+    expect(res.body.announcements[0].fairStartTime).toBe(500);
+    expect(res.body.announcements[0].fairEndTime).toBe(2000);
+    expect(res.body.announcements[0].title).toBe("Reminder");
+    expect(res.body.announcements[0].description).toBe("Q&A at noon");
+  });
+});
+
+/* =======================================================
+   Fair announcements (admin CRUD)
+======================================================= */
+describe("Fair announcements admin API", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("GET /api/fairs/:fairId/announcements returns 401 without token", async () => {
+    const res = await request(app).get("/api/fairs/fair-id/announcements");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/fairs/:fairId/announcements returns 403 when not admin", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    setupFairsDbMock({ fairData: FAIR_DATA });
+    const res = await request(app)
+      .get("/api/fairs/fair-id/announcements")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /api/fairs/:fairId/announcements lists announcements", async () => {
+    verifyAdmin.mockResolvedValue(null);
+    const annDoc = {
+      id: "ann-1",
+      data: () => ({
+        title: "Parking",
+        description: "Info session",
+        published: false,
+        createdAt: { toMillis: () => 1 },
+        updatedAt: { toMillis: () => 2 },
+        createdBy: "admin-uid",
+      }),
+    };
+    setupFairsDbMock({
+      fairData: FAIR_DATA,
+      announcementListDocs: [annDoc],
+    });
+    const res = await request(app)
+      .get("/api/fairs/fair-id/announcements")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.announcements).toHaveLength(1);
+    expect(res.body.announcements[0].id).toBe("ann-1");
+    expect(res.body.announcements[0].title).toBe("Parking");
+    expect(res.body.announcements[0].description).toBe("Info session");
+    expect(res.body.announcements[0].published).toBe(false);
+  });
+
+  it("POST /api/fairs/:fairId/announcements creates announcement", async () => {
+    verifyAdmin.mockResolvedValue(null);
+    setupFairsDbMock({ fairData: FAIR_DATA });
+    const res = await request(app)
+      .post("/api/fairs/fair-id/announcements")
+      .set("Authorization", authHeader())
+      .send({
+        title: "Employer meetup",
+        description: "Optional details",
+        published: true,
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("new-announcement-id");
+    expect(res.body.title).toBe("Posted title");
+    expect(res.body.description).toBe("New session");
+  });
+
+  it("POST returns 400 when title missing", async () => {
+    verifyAdmin.mockResolvedValue(null);
+    setupFairsDbMock({ fairData: FAIR_DATA });
+    const res = await request(app)
+      .post("/api/fairs/fair-id/announcements")
+      .set("Authorization", authHeader())
+      .send({ description: "Only body" });
+    expect(res.status).toBe(400);
+  });
+
+  it("PUT /api/fairs/:fairId/announcements/:id updates announcement", async () => {
+    verifyAdmin.mockResolvedValue(null);
+    setupFairsDbMock({
+      fairData: FAIR_DATA,
+      announcementDocForPutDelete: {
+        title: "Old title",
+        description: "Old",
+        published: false,
+        createdAt: { toMillis: () => 1 },
+        updatedAt: { toMillis: () => 2 },
+        createdBy: "admin-uid",
+      },
+    });
+    const res = await request(app)
+      .put("/api/fairs/fair-id/announcements/ann-1")
+      .set("Authorization", authHeader())
+      .send({ description: "Updated text", published: true });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe("Updated text");
+    expect(res.body.published).toBe(true);
+  });
+
+  it("DELETE /api/fairs/:fairId/announcements/:id returns 204", async () => {
+    verifyAdmin.mockResolvedValue(null);
+    setupFairsDbMock({
+      fairData: FAIR_DATA,
+      announcementDocForPutDelete: {
+        title: "T",
+        description: "x",
+        published: true,
+        publishedAt: { toMillis: () => 1 },
+        createdAt: { toMillis: () => 1 },
+        updatedAt: { toMillis: () => 2 },
+        createdBy: "admin-uid",
+      },
+    });
+    const res = await request(app)
+      .delete("/api/fairs/fair-id/announcements/ann-1")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(204);
   });
 });
 

--- a/backend/__tests__/fairs3.test.js
+++ b/backend/__tests__/fairs3.test.js
@@ -879,6 +879,414 @@ describe("POST /api/fairs/:fairId/enroll – helper branches", () => {
     expect(batch.commit).toHaveBeenCalled();
   });
 
+  it("enrollment merges global booth doc into boothSnapshot when company has boothId (getCompanyAndBoothSnapshot)", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    const batch = makeBatch();
+    db.batch.mockReturnValue(batch);
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ name: "Spring Fair" }, true, "fair-id")),
+            collection: jest.fn((sub) => {
+              if (sub === "enrollments") {
+                return {
+                  doc: jest.fn(() => ({
+                    get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+                  })),
+                };
+              }
+              if (sub === "booths") {
+                return {
+                  doc: jest.fn(() => ({ id: "fairBooth1" })),
+                };
+              }
+              if (sub === "jobs") {
+                return {
+                  doc: jest.fn(() => ({ id: "fairJob1" })),
+                };
+              }
+              return { doc: jest.fn(() => ({ id: "x" })) };
+            }),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                {
+                  companyName: "Acme",
+                  ownerId: "owner-booth",
+                  boothId: "global-booth-99",
+                },
+                true,
+                "comp-booth",
+              ),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      if (name === "booths") {
+        return {
+          doc: jest.fn((bid) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                {
+                  companyName: "From Global Booth",
+                  industry: "Software",
+                  companySize: "50",
+                  location: "Remote",
+                  locationIsRemote: true,
+                  locationCity: "Boston",
+                  locationState: "MA",
+                  description: "Desc",
+                  logoUrl: "https://logo",
+                  website: "https://w",
+                  careersPage: "https://c",
+                  contactName: "Pat",
+                  contactEmail: "p@x.com",
+                  contactPhone: "555",
+                  hiringFor: "Devs",
+                },
+                true,
+                bid,
+              ),
+            ),
+          })),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-booth"))
+      .send({ companyId: "comp-booth" });
+
+    expect(res.status).toBe(201);
+    expect(batch.set).toHaveBeenCalled();
+    const boothPayload = batch.set.mock.calls.find((c) => {
+      const data = c[1];
+      return data && data.companyName === "From Global Booth" && data.originalBoothId === "global-booth-99";
+    });
+    expect(boothPayload).toBeDefined();
+  });
+
+  it("resolveCompanyIdForEnrollment returns sole owned company for companyOwner (inviteCode)", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    const batch = makeBatch();
+    db.batch.mockReturnValue(batch);
+    const code = "SINGLEOWN1";
+    const fairDocWithHmac = { ...FAIR_DATA, inviteCode: code.toUpperCase() };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(fairDocWithHmac, true, "fair-id")),
+            collection: jest.fn((sub) => {
+              if (sub === "enrollments") {
+                return {
+                  doc: jest.fn(() => ({
+                    get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+                  })),
+                };
+              }
+              if (sub === "booths") {
+                return { doc: jest.fn(() => ({ id: "fairBooth1" })) };
+              }
+              if (sub === "jobs") {
+                return { doc: jest.fn(() => ({ id: "fairJob1" })) };
+              }
+              return { doc: jest.fn(() => ({ id: "x" })) };
+            }),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: false,
+            docs: [{ id: "fair-id", data: () => fairDocWithHmac }],
+          }),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ role: "companyOwner" }, true, "owner-solo")),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn((id) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ companyName: "Solo Co", ownerId: "owner-solo" }, true, id),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(
+            mockQuerySnap([{ id: "solo-co", data: () => ({ ownerId: "owner-solo" }) }]),
+          ),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-solo"))
+      .send({ inviteCode: code });
+
+    expect(res.status).toBe(201);
+    expect(res.body.fairId).toBe("fair-id");
+    expect(batch.commit).toHaveBeenCalled();
+  });
+
+  it("resolveCompanyIdForEnrollment uses profile companyId when companyOwner has no owned rows (inviteCode)", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    const batch = makeBatch();
+    db.batch.mockReturnValue(batch);
+    const code = "PROFILEO1";
+    const fairDocWithHmac = { ...FAIR_DATA, inviteCode: code.toUpperCase() };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(fairDocWithHmac, true, "fair-id")),
+            collection: jest.fn((sub) => {
+              if (sub === "enrollments") {
+                return {
+                  doc: jest.fn(() => ({
+                    get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+                  })),
+                };
+              }
+              if (sub === "booths") {
+                return { doc: jest.fn(() => ({ id: "fairBooth1" })) };
+              }
+              if (sub === "jobs") {
+                return { doc: jest.fn(() => ({ id: "fairJob1" })) };
+              }
+              return { doc: jest.fn(() => ({ id: "x" })) };
+            }),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: false,
+            docs: [{ id: "fair-id", data: () => fairDocWithHmac }],
+          }),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "companyOwner", companyId: "profile-co" }, true, "owner-prof"),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn((id) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ companyName: "Profile Co", ownerId: "owner-prof" }, true, id),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-prof"))
+      .send({ inviteCode: code });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 400 when companyOwner has no profile companyId and no owned companies (resolveCompanyId line 147)", async () => {
+    db.batch.mockReturnValue(makeBatch());
+    const code = "ORPHANOWN";
+    const fairDocWithHmac = { ...FAIR_DATA, inviteCode: code.toUpperCase() };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(fairDocWithHmac, true, "fair-id")),
+            collection: jest.fn(() => ({
+              doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+              get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+            })),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: false,
+            docs: [{ id: "fair-id", data: () => fairDocWithHmac }],
+          }),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "companyOwner" }, true, "owner-orphan"),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-orphan"))
+      .send({ inviteCode: code });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not associated with a company/i);
+  });
+
+  it("resolveCompanyIdForEnrollment returns profile company for representative (inviteCode, line 151)", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    const batch = makeBatch();
+    db.batch.mockReturnValue(batch);
+    const code = "REPINVITE1";
+    const fairDocWithHmac = { ...FAIR_DATA, inviteCode: code.toUpperCase() };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(fairDocWithHmac, true, "fair-id")),
+            collection: jest.fn((sub) => {
+              if (sub === "enrollments") {
+                return {
+                  doc: jest.fn(() => ({
+                    get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+                  })),
+                };
+              }
+              if (sub === "booths") {
+                return { doc: jest.fn(() => ({ id: "fairBooth1" })) };
+              }
+              if (sub === "jobs") {
+                return { doc: jest.fn(() => ({ id: "fairJob1" })) };
+              }
+              return { doc: jest.fn(() => ({ id: "x" })) };
+            }),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: false,
+            docs: [{ id: "fair-id", data: () => fairDocWithHmac }],
+          }),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                { role: "representative", companyId: "rep-co-enroll" },
+                true,
+                "rep-user-1",
+              ),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn((id) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                {
+                  companyName: "Rep Co",
+                  ownerId: "some-owner",
+                  representativeIDs: ["rep-user-1"],
+                },
+                true,
+                id,
+              ),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("rep-user-1"))
+      .send({ inviteCode: code });
+
+    expect(res.status).toBe(201);
+    expect(batch.commit).toHaveBeenCalled();
+  });
+
   it("returns 500 when DB throws during enrollment", async () => {
     db.batch.mockReturnValue(makeBatch());
     db.collection.mockImplementation(() => ({

--- a/backend/__tests__/fairs3.test.js
+++ b/backend/__tests__/fairs3.test.js
@@ -697,6 +697,188 @@ describe("POST /api/fairs/:fairId/enroll – helper branches", () => {
     expect(res.body.error).toMatch(/not associated with a company/i);
   });
 
+  it("returns 400 COMPANY_ID_REQUIRED when company owner has multiple owned companies (resolveCompanyIdForEnrollment)", async () => {
+    db.batch.mockReturnValue(makeBatch());
+    const code = "MULTIOWN1";
+    const fairDocWithHmac = { ...FAIR_DATA, inviteCode: code.toUpperCase() };
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(fairDocWithHmac, true, "fair-id")),
+            collection: jest.fn(() => ({
+              doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+              get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+            })),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: false,
+            docs: [{ id: "fair-id", data: () => fairDocWithHmac }],
+          }),
+        };
+      }
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "companyOwner", companyId: null }, true, "owner-multi"),
+            ),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(
+            mockQuerySnap([
+              { id: "c-one", data: () => ({}) },
+              { id: "c-two", data: () => ({}) },
+            ]),
+          ),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-multi"))
+      .send({ inviteCode: code });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("COMPANY_ID_REQUIRED");
+    expect(res.body.error).toMatch(/multiple companies/i);
+  });
+
+  it("returns 403 from ensureAdminOrCompanyAccess when user is not admin and not a company member", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    db.batch.mockReturnValue(makeBatch());
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap(FAIR_DATA, true, "fair-id")),
+            collection: jest.fn(() => ({
+              doc: jest.fn(() => ({
+                get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+              })),
+              get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+            })),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn((id) => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                {
+                  ownerId: "someone-else",
+                  representativeIDs: [],
+                  companyName: "Other Co",
+                },
+                true,
+                id,
+              ),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("stranger-uid"))
+      .send({ companyId: "evil-corp" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Unauthorized: must be admin or company owner/rep");
+  });
+
+  it("allows enrollment when user is company owner of the company (ensureAdminOrCompanyAccess via verifyCompanyAccess)", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Only administrators can manage schedules", status: 403 });
+    const batch = makeBatch();
+    db.batch.mockReturnValue(batch);
+
+    db.collection.mockImplementation((name) => {
+      if (name === "fairs") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(mockDocSnap({ name: "Spring Fair" }, true, "fair-id")),
+            collection: jest.fn((sub) => {
+              if (sub === "enrollments") {
+                return {
+                  doc: jest.fn(() => ({
+                    get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
+                  })),
+                };
+              }
+              if (sub === "booths") {
+                return {
+                  doc: jest.fn(() => ({ id: "fairBooth1" })),
+                };
+              }
+              if (sub === "jobs") {
+                return {
+                  doc: jest.fn(() => ({ id: "fairJob1" })),
+                };
+              }
+              return { doc: jest.fn(() => ({ id: "x" })) };
+            }),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ companyName: "Acme", ownerId: "owner-enroll" }, true, "comp-enroll"),
+            ),
+          })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      if (name === "jobs") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        };
+      }
+      return {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+        doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) })),
+      };
+    });
+
+    const res = await request(app)
+      .post("/api/fairs/fair-id/enroll")
+      .set("Authorization", authHeader("owner-enroll"))
+      .send({ companyId: "comp-enroll" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.fairId).toBe("fair-id");
+    expect(batch.commit).toHaveBeenCalled();
+  });
+
   it("returns 500 when DB throws during enrollment", async () => {
     db.batch.mockReturnValue(makeBatch());
     db.collection.mockImplementation(() => ({

--- a/backend/__tests__/fairs3.test.js
+++ b/backend/__tests__/fairs3.test.js
@@ -1271,10 +1271,13 @@ describe("DELETE /api/fairs/:fairId/leave", () => {
         };
       }
       if (name === "companies") {
+        const companySnap = mockDocSnap({ ownerId: "user-id", representativeIDs: [] }, true, "company-id");
         return {
           doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(mockDocSnap({ ownerId: "user-id", representativeIDs: [] }, true, "company-id")),
+            get: jest.fn().mockResolvedValue(companySnap),
           })),
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue(mockQuerySnap([companySnap])),
         };
       }
       if (name === "fairs") {

--- a/backend/routes/fairs.js
+++ b/backend/routes/fairs.js
@@ -53,9 +53,10 @@ async function getRequestingRoleFromAuthHeader(authHeader) {
   return null;
 }
 
-function buildHttpError(status, message) {
+function buildHttpError(status, message, code) {
   const err = new Error(message);
   err.status = status;
+  if (code) err.code = code;
   return err;
 }
 
@@ -89,16 +90,65 @@ async function ensureFairExists(fairId) {
   if (!fairDoc.exists) throw buildHttpError(404, "Fair not found");
 }
 
+/** Millisecond fair window for clients (e.g. “past fair” badges). Omit or pass null fields when unknown. */
+function fairScheduleFromFairData(fairData) {
+  if (!fairData) return {};
+  return {
+    fairStartTime: fairData.startTime ? fairData.startTime.toMillis() : null,
+    fairEndTime: fairData.endTime ? fairData.endTime.toMillis() : null,
+  };
+}
+
+/** Serialize a fair announcement Firestore doc for JSON responses (title + optional description; sorted by createdAt elsewhere). */
+function serializeAnnouncementDoc(doc, fairId, fairName, fairSchedule) {
+  const d = doc.data() || {};
+  const title = d.title != null ? String(d.title).trim() : "";
+  const description = d.description != null ? String(d.description).trim() : "";
+  const sched = fairSchedule && typeof fairSchedule === "object" ? fairSchedule : {};
+  return {
+    id: doc.id,
+    fairId,
+    fairName: fairName ?? null,
+    title,
+    description,
+    published: Boolean(d.published),
+    publishedAt: d.publishedAt ? d.publishedAt.toMillis() : null,
+    createdAt: d.createdAt ? d.createdAt.toMillis() : null,
+    updatedAt: d.updatedAt ? d.updatedAt.toMillis() : null,
+    createdBy: d.createdBy || null,
+    fairStartTime: sched.fairStartTime ?? null,
+    fairEndTime: sched.fairEndTime ?? null,
+  };
+}
+
 async function resolveCompanyIdForEnrollment(requestingUid, companyId) {
   if (companyId) return companyId;
 
   const userDoc = await db.collection("users").doc(requestingUid).get();
   if (!userDoc.exists) throw buildHttpError(404, "User not found");
+  const userData = userDoc.data();
+  const role = userData.role;
+  const profileCompanyId = userData.companyId || null;
 
-  const resolvedCompanyId = userDoc.data().companyId;
-  if (!resolvedCompanyId) throw buildHttpError(400, "User is not associated with a company");
+  if (role === "companyOwner") {
+    const ownedSnap = await db.collection("companies").where("ownerId", "==", requestingUid).get();
+    const ownedIds = ownedSnap.docs.map((d) => d.id);
+    if (ownedIds.length > 1) {
+      throw buildHttpError(
+        400,
+        "You manage multiple companies. Select which company to enroll in this fair.",
+        "COMPANY_ID_REQUIRED",
+      );
+    }
+    if (ownedIds.length === 1) {
+      return ownedIds[0];
+    }
+    if (profileCompanyId) return profileCompanyId;
+    throw buildHttpError(400, "User is not associated with a company");
+  }
 
-  return resolvedCompanyId;
+  if (!profileCompanyId) throw buildHttpError(400, "User is not associated with a company");
+  return profileCompanyId;
 }
 
 
@@ -339,24 +389,114 @@ router.get("/fairs/my-enrollments", verifyFirebaseToken, async (req, res) => {
   try {
     const userDoc = await db.collection("users").doc(req.user.uid).get();
     if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
-    const companyId = userDoc.data().companyId;
-    if (!companyId) return res.json({ enrollments: [] });
+    const userData = userDoc.data();
+    const role = userData.role;
+    const profileCompanyId = userData.companyId || null;
+
+    const companyIds = new Set();
+    if (profileCompanyId) companyIds.add(profileCompanyId);
+    if (role === "companyOwner") {
+      const ownedSnap = await db.collection("companies").where("ownerId", "==", req.user.uid).get();
+      ownedSnap.docs.forEach((d) => companyIds.add(d.id));
+    } else if (role === "representative" && profileCompanyId) {
+      companyIds.clear();
+      companyIds.add(profileCompanyId);
+    }
+
+    if (companyIds.size === 0) return res.json({ enrollments: [] });
 
     const fairsSnap = await db.collection("fairs").get();
-    const enrollmentChecks = fairsSnap.docs.map((fairDoc) =>
-      db.collection("fairs").doc(fairDoc.id).collection("enrollments").doc(companyId).get()
-        .then((enrollDoc) => enrollDoc.exists ? {
-          fairId: fairDoc.id,
-          boothId: enrollDoc.data().boothId || null,
-          enrolledAt: enrollDoc.data().enrolledAt ? enrollDoc.data().enrolledAt.toMillis() : null,
-        } : null)
-    );
-    const enrollments = (await Promise.all(enrollmentChecks)).filter(Boolean);
+    const enrollments = [];
+
+    for (const fairDoc of fairsSnap.docs) {
+      for (const cid of companyIds) {
+        const enrollDoc = await db
+          .collection("fairs")
+          .doc(fairDoc.id)
+          .collection("enrollments")
+          .doc(cid)
+          .get();
+        if (enrollDoc.exists) {
+          enrollments.push({
+            fairId: fairDoc.id,
+            companyId: cid,
+            boothId: enrollDoc.data().boothId || null,
+            enrolledAt: enrollDoc.data().enrolledAt ? enrollDoc.data().enrolledAt.toMillis() : null,
+          });
+        }
+      }
+    }
 
     return res.json({ enrollments });
   } catch (err) {
     console.error("GET /api/fairs/my-enrollments error:", err);
     return res.status(500).json({ error: "Failed to fetch enrollments" });
+  }
+});
+
+/* GET /api/fairs/my-announcements — company owner / rep: published announcements for enrolled fairs */
+router.get("/fairs/my-announcements", verifyFirebaseToken, async (req, res) => {
+  try {
+    const userDoc = await db.collection("users").doc(req.user.uid).get();
+    if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+    const userData = userDoc.data();
+    const role = userData.role;
+    const profileCompanyId = userData.companyId || null;
+
+    if (role !== "companyOwner" && role !== "representative") {
+      return res.json({ announcements: [] });
+    }
+
+    const companyIds = new Set();
+    if (profileCompanyId) companyIds.add(profileCompanyId);
+    if (role === "companyOwner") {
+      const ownedSnap = await db.collection("companies").where("ownerId", "==", req.user.uid).get();
+      ownedSnap.docs.forEach((d) => companyIds.add(d.id));
+    } else if (role === "representative" && profileCompanyId) {
+      companyIds.clear();
+      companyIds.add(profileCompanyId);
+    }
+
+    if (companyIds.size === 0) return res.json({ announcements: [] });
+
+    const fairsSnap = await db.collection("fairs").get();
+    const perFair = await Promise.all(
+      fairsSnap.docs.map(async (fairDoc) => {
+        let isEnrolled = false;
+        for (const cid of companyIds) {
+          const enrollDoc = await db
+            .collection("fairs")
+            .doc(fairDoc.id)
+            .collection("enrollments")
+            .doc(cid)
+            .get();
+          if (enrollDoc.exists) {
+            isEnrolled = true;
+            break;
+          }
+        }
+        if (!isEnrolled) return [];
+
+        const fairData = fairDoc.data() || {};
+        const fairName = fairData.name || null;
+        const fairSchedule = fairScheduleFromFairData(fairData);
+        const annSnap = await db.collection("fairs").doc(fairDoc.id).collection("announcements").get();
+        const items = [];
+        annSnap.docs.forEach((annDoc) => {
+          const ann = annDoc.data() || {};
+          if (!ann.published) return;
+          items.push(serializeAnnouncementDoc(annDoc, fairDoc.id, fairName, fairSchedule));
+        });
+        return items;
+      })
+    );
+
+    const announcements = perFair.flat();
+    announcements.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    return res.json({ announcements });
+  } catch (err) {
+    console.error("GET /api/fairs/my-announcements error:", err);
+    return res.status(500).json({ error: "Failed to fetch announcements" });
   }
 });
 
@@ -406,6 +546,139 @@ router.get("/fairs/:fairId/status", async (req, res) => {
     if (err.message === "Fair not found") return res.status(404).json({ error: "Fair not found" });
     console.error("GET /api/fairs/:fairId/status error:", err);
     return res.status(500).json({ error: "Failed to get fair status" });
+  }
+});
+
+/* GET /api/fairs/:fairId/announcements — admin: list announcements (drafts + published) */
+router.get("/fairs/:fairId/announcements", verifyFirebaseToken, async (req, res) => {
+  const { fairId } = req.params;
+  const adminError = await verifyAdmin(req.user.uid);
+  if (adminError) return res.status(adminError.status).json({ error: adminError.error });
+
+  try {
+    await ensureFairExists(fairId);
+    const fairDoc = await db.collection("fairs").doc(fairId).get();
+    const fairData = fairDoc.data() || {};
+    const fairName = fairData.name || null;
+    const fairSchedule = fairScheduleFromFairData(fairData);
+    const snap = await db.collection("fairs").doc(fairId).collection("announcements").get();
+    const announcements = snap.docs.map((doc) => serializeAnnouncementDoc(doc, fairId, fairName, fairSchedule));
+    announcements.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    return res.json({ announcements });
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: err.message });
+    console.error("GET /api/fairs/:fairId/announcements error:", err);
+    return res.status(500).json({ error: "Failed to list announcements" });
+  }
+});
+
+/* POST /api/fairs/:fairId/announcements — admin: create announcement */
+router.post("/fairs/:fairId/announcements", verifyFirebaseToken, async (req, res) => {
+  const { fairId } = req.params;
+  const adminError = await verifyAdmin(req.user.uid);
+  if (adminError) return res.status(adminError.status).json({ error: adminError.error });
+
+  const { title, description, published } = req.body;
+  if (!title || !String(title).trim()) {
+    return res.status(400).json({ error: "title is required" });
+  }
+
+  try {
+    await ensureFairExists(fairId);
+
+    const now = admin.firestore.Timestamp.now();
+    const isPublished = Boolean(published);
+    const fairDoc = await db.collection("fairs").doc(fairId).get();
+    const fairDataPost = fairDoc.data() || {};
+    const fairName = fairDataPost.name || null;
+    const fairSchedulePost = fairScheduleFromFairData(fairDataPost);
+
+    const descTrim = description != null ? String(description).trim() : "";
+    const payload = removeUndefined({
+      title: String(title).trim(),
+      ...(descTrim ? { description: descTrim } : {}),
+      published: isPublished,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: req.user.uid,
+      ...(isPublished ? { publishedAt: now } : {}),
+    });
+
+    const colRef = db.collection("fairs").doc(fairId).collection("announcements");
+    const docRef = await colRef.add(payload);
+    const created = await docRef.get();
+    return res.status(201).json(serializeAnnouncementDoc(created, fairId, fairName, fairSchedulePost));
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: err.message });
+    console.error("POST /api/fairs/:fairId/announcements error:", err);
+    return res.status(500).json({ error: "Failed to create announcement" });
+  }
+});
+
+/* PUT /api/fairs/:fairId/announcements/:announcementId — admin: update announcement */
+router.put("/fairs/:fairId/announcements/:announcementId", verifyFirebaseToken, async (req, res) => {
+  const { fairId, announcementId } = req.params;
+  const adminError = await verifyAdmin(req.user.uid);
+  if (adminError) return res.status(adminError.status).json({ error: adminError.error });
+
+  try {
+    await ensureFairExists(fairId);
+    const annRef = db.collection("fairs").doc(fairId).collection("announcements").doc(announcementId);
+    const annDoc = await annRef.get();
+    if (!annDoc.exists) return res.status(404).json({ error: "Announcement not found" });
+
+    const prev = annDoc.data() || {};
+    const updates = { updatedAt: admin.firestore.Timestamp.now() };
+
+    if (req.body.title !== undefined) {
+      if (!String(req.body.title).trim()) {
+        return res.status(400).json({ error: "title cannot be empty" });
+      }
+      updates.title = String(req.body.title).trim();
+    }
+    if (req.body.description !== undefined) {
+      const t = req.body.description === null || req.body.description === "" ? "" : String(req.body.description).trim();
+      updates.description = t;
+    }
+    if (req.body.published !== undefined) {
+      const nextPub = Boolean(req.body.published);
+      updates.published = nextPub;
+      if (nextPub && !prev.published) {
+        updates.publishedAt = admin.firestore.Timestamp.now();
+      }
+    }
+
+    await annRef.update(removeUndefined(updates));
+    const after = await annRef.get();
+    const fairDoc = await db.collection("fairs").doc(fairId).get();
+    const fairDataPut = fairDoc.data() || {};
+    const fairName = fairDataPut.name || null;
+    const fairSchedulePut = fairScheduleFromFairData(fairDataPut);
+    return res.json(serializeAnnouncementDoc(after, fairId, fairName, fairSchedulePut));
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: err.message });
+    console.error("PUT /api/fairs/:fairId/announcements/:announcementId error:", err);
+    return res.status(500).json({ error: "Failed to update announcement" });
+  }
+});
+
+/* DELETE /api/fairs/:fairId/announcements/:announcementId — admin: delete announcement */
+router.delete("/fairs/:fairId/announcements/:announcementId", verifyFirebaseToken, async (req, res) => {
+  const { fairId, announcementId } = req.params;
+  const adminError = await verifyAdmin(req.user.uid);
+  if (adminError) return res.status(adminError.status).json({ error: adminError.error });
+
+  try {
+    await ensureFairExists(fairId);
+    const annRef = db.collection("fairs").doc(fairId).collection("announcements").doc(announcementId);
+    const annDoc = await annRef.get();
+    if (!annDoc.exists) return res.status(404).json({ error: "Announcement not found" });
+    await annRef.delete();
+    return res.status(204).send();
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: err.message });
+    console.error("DELETE /api/fairs/:fairId/announcements/:announcementId error:", err);
+    return res.status(500).json({ error: "Failed to delete announcement" });
   }
 });
 
@@ -805,7 +1078,12 @@ router.post("/fairs/:fairId/enroll", enrollmentLimiter, verifyFirebaseToken, asy
 
     return res.status(201).json({ boothId, fairId: resolvedFairId });
   } catch (err) {
-    if (err.status) return res.status(err.status).json({ error: err.message });
+    if (err.status) {
+      return res.status(err.status).json({
+        error: err.message,
+        ...(err.code ? { code: err.code } : {}),
+      });
+    }
     console.error("POST /api/fairs/:fairId/enroll error:", err);
     return res.status(500).json({ error: "Failed to enroll company" });
   }
@@ -1265,12 +1543,45 @@ router.get("/companies/:companyId/fairs", verifyFirebaseToken, async (req, res) 
 router.delete("/fairs/:fairId/leave", verifyFirebaseToken, async (req, res) => {
   const { fairId } = req.params;
   const requestingUid = req.user.uid;
+  const bodyCompanyId =
+    req.body && typeof req.body.companyId === "string" ? req.body.companyId.trim() : null;
 
   try {
     const userDoc = await db.collection("users").doc(requestingUid).get();
     if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+    const userData = userDoc.data();
+    const role = userData.role;
+    const profileCompanyId = userData.companyId || null;
 
-    const companyId = userDoc.data().companyId;
+    let companyId = bodyCompanyId || null;
+
+    if (!companyId && role === "companyOwner") {
+      const ownedSnap = await db.collection("companies").where("ownerId", "==", requestingUid).get();
+      const ownedIds = ownedSnap.docs.map((d) => d.id);
+      const enrolledIds = [];
+      for (const cid of ownedIds) {
+        const ed = await db
+          .collection("fairs")
+          .doc(fairId)
+          .collection("enrollments")
+          .doc(cid)
+          .get();
+        if (ed.exists) enrolledIds.push(cid);
+      }
+      if (enrolledIds.length === 1) {
+        companyId = enrolledIds[0];
+      } else if (enrolledIds.length > 1) {
+        return res.status(400).json({
+          error: "You have multiple companies enrolled in this fair. Choose which company to remove.",
+          code: "COMPANY_ID_REQUIRED",
+        });
+      }
+    }
+
+    if (!companyId) {
+      companyId = profileCompanyId;
+    }
+
     if (!companyId) return res.status(400).json({ error: "You are not associated with a company" });
 
     // Must be owner or rep of the company

--- a/backend/routes/fairs.js
+++ b/backend/routes/fairs.js
@@ -1772,4 +1772,12 @@ router.get("/fairs/:fairId/lounge/attendees", verifyFirebaseToken, async (req, r
   }
 });
 
+if (process.env.NODE_ENV === "test") {
+  router.testHelpers = {
+    fairScheduleFromFairData,
+    serializeAnnouncementDoc,
+    getCompanyAndBoothSnapshot,
+  };
+}
+
 module.exports = router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { EmployerMyCalls } from "./pages/EmployerMyCalls"
 import { Call1x1Room } from "./components/videoChat/Call1x1Room"
 import BaseLayout from "./components/BaseLayout"
 import FairyJobmotherPage from "./pages/FairyJobmotherPage"
+import FairAnnouncementsPage from "./pages/FairAnnouncementsPage"
 import { FairProvider } from "./contexts/FairContext"
 import { setupConsoleErrorFilter } from "./utils/consoleErrorFilter"
 
@@ -96,6 +97,7 @@ function App() {
 
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/dashboard/fairy-jobmother" element={<FairyJobmotherPage />} />
+        <Route path="/dashboard/fair-announcements" element={<FairAnnouncementsPage />} />
         <Route path="/dashboard/chat" element={<ChatPage />} />
         <Route path="/dashboard/booth-history" element={<BoothHistoryPage />} />
         <Route path="/dashboard/job-invitations" element={<JobInvitations />} />

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -6,6 +6,8 @@ vi.mock("../pages/RoleSelection", () => ({ default: () => <div>RoleSelection</di
 vi.mock("../pages/Register", () => ({ default: () => <div>Register</div> }))
 vi.mock("../pages/Login", () => ({ default: () => <div>Login</div> }))
 vi.mock("../pages/Dashboard", () => ({ default: () => <div>Dashboard</div> }))
+vi.mock("../pages/FairyJobmotherPage", () => ({ default: () => <div>FairyJobmotherPage</div> }))
+vi.mock("../pages/FairAnnouncementsPage", () => ({ default: () => <div>FairAnnouncementsPage</div> }))
 vi.mock("../pages/CompanyManagement", () => ({ default: () => <div>CompanyManagement</div> }))
 vi.mock("../pages/Company", () => ({ default: () => <div>Company</div> }))
 vi.mock("../pages/BoothEditor", () => ({ default: () => <div>BoothEditor</div> }))
@@ -172,6 +174,18 @@ describe("App", () => {
     globalThis.history.pushState({}, "", "/dashboard")
     render(<App />)
     expect(screen.getByText("Dashboard")).toBeInTheDocument()
+  })
+
+  it("renders FairyJobmotherPage at /dashboard/fairy-jobmother", () => {
+    globalThis.history.pushState({}, "", "/dashboard/fairy-jobmother")
+    render(<App />)
+    expect(screen.getByText("FairyJobmotherPage")).toBeInTheDocument()
+  })
+
+  it("renders FairAnnouncementsPage at /dashboard/fair-announcements", () => {
+    globalThis.history.pushState({}, "", "/dashboard/fair-announcements")
+    render(<App />)
+    expect(screen.getByText("FairAnnouncementsPage")).toBeInTheDocument()
   })
 
   it("renders AdminDashboard at /admin", () => {

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,5 +1,10 @@
+vi.mock("../utils/consoleErrorFilter", () => ({
+  setupConsoleErrorFilter: vi.fn(),
+}))
+
 import { render, screen } from "@testing-library/react"
 import { describe, it, expect, vi, afterEach } from "vitest"
+import { setupConsoleErrorFilter } from "../utils/consoleErrorFilter"
 import App from "../App"
 
 vi.mock("../pages/RoleSelection", () => ({ default: () => <div>RoleSelection</div> }))
@@ -55,6 +60,10 @@ vi.mock("../contexts/FairContext", () => ({
 describe("App", () => {
   afterEach(() => {
     globalThis.history.pushState({}, "", "/")
+  })
+
+  it("calls setupConsoleErrorFilter when the App module loads (TensorFlow console noise)", () => {
+    expect(vi.mocked(setupConsoleErrorFilter)).toHaveBeenCalled()
   })
 
   it("renders RoleSelection at /", () => {

--- a/frontend/src/__tests__/firebase.test.ts
+++ b/frontend/src/__tests__/firebase.test.ts
@@ -7,7 +7,8 @@ vi.mock("firebase/app", () => ({
 }));
 
 vi.mock("firebase/auth", () => ({
-  getAuth: vi.fn(() => ({ name: "mock-auth" })),
+  getAuth: vi.fn(() => ({ name: "mock-auth", currentUser: null })),
+  onAuthStateChanged: vi.fn(),
   GoogleAuthProvider: class MockGoogleAuthProvider {
     name = "mock-google-provider";
   },

--- a/frontend/src/__tests__/waitForFirebaseUser.test.ts
+++ b/frontend/src/__tests__/waitForFirebaseUser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { User } from "firebase/auth"
+
+/** Production code passes a function; Firebase types allow Observer too. */
+function asAuthCallback(nextOrObserver: unknown): (user: User | null) => void {
+  return nextOrObserver as (user: User | null) => void
+}
+
+const authState = { currentUser: null as { uid: string; getIdToken?: () => Promise<string> } | null }
+const mockUnsub = vi.fn()
+
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(() => ({})),
+}))
+
+vi.mock("firebase/auth", () => ({
+  getAuth: vi.fn(() => ({
+    get currentUser() {
+      return authState.currentUser
+    },
+  })),
+  onAuthStateChanged: vi.fn(),
+  GoogleAuthProvider: class MockGoogleAuthProvider {
+    static readonly providerId = "google.com"
+  },
+}))
+
+vi.mock("firebase/firestore", () => ({
+  getFirestore: vi.fn(() => ({})),
+}))
+
+vi.mock("firebase/storage", () => ({
+  getStorage: vi.fn(() => ({})),
+}))
+
+describe("waitForFirebaseUser", () => {
+  beforeEach(async () => {
+    authState.currentUser = null
+    vi.resetModules()
+    vi.clearAllMocks()
+    const { onAuthStateChanged } = await import("firebase/auth")
+    vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+      const next = asAuthCallback(callback)
+      queueMicrotask(() => {
+        next({ uid: "auth-flow-user", getIdToken: async () => "tok" } as User)
+      })
+      return mockUnsub
+    })
+  })
+
+  it("resolves immediately with currentUser when already present (fast path)", async () => {
+    authState.currentUser = { uid: "already-here", getIdToken: async () => "t" }
+    const { waitForFirebaseUser } = await import("../firebase")
+    const u = await waitForFirebaseUser()
+    expect(u).toBe(authState.currentUser)
+    expect(vi.mocked((await import("firebase/auth")).onAuthStateChanged)).not.toHaveBeenCalled()
+  })
+
+  it("subscribes via onAuthStateChanged and resolves when user is emitted", async () => {
+    const { onAuthStateChanged } = await import("firebase/auth")
+    authState.currentUser = null
+    const { waitForFirebaseUser } = await import("../firebase")
+    const u = await waitForFirebaseUser()
+    expect(onAuthStateChanged).toHaveBeenCalled()
+    expect(u).toMatchObject({ uid: "auth-flow-user" })
+    expect(mockUnsub).toHaveBeenCalled()
+  })
+
+  it("ignores a null auth callback then resolves on the next user", async () => {
+    const { onAuthStateChanged } = await import("firebase/auth")
+    vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+      const next = asAuthCallback(callback)
+      queueMicrotask(() => {
+        next(null)
+        queueMicrotask(() => {
+          next({ uid: "after-null", getIdToken: async () => "t" } as User)
+        })
+      })
+      return mockUnsub
+    })
+    authState.currentUser = null
+    const { waitForFirebaseUser } = await import("../firebase")
+    const u = await waitForFirebaseUser()
+    expect(u).toMatchObject({ uid: "after-null" })
+  })
+})

--- a/frontend/src/components/BaseLayout.tsx
+++ b/frontend/src/components/BaseLayout.tsx
@@ -33,6 +33,7 @@ import PresentationIcon from "@mui/icons-material/Slideshow"
 import PeopleIcon from "@mui/icons-material/People"
 import WorkIcon from "@mui/icons-material/Work"
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome"
+import CampaignIcon from "@mui/icons-material/Campaign"
 import NotificationBell from "./NotificationBell"
 import ProfileMenu from "../pages/ProfileMenu"
 import FairyJobmotherAssistant from "./jobmother/FairyJobmotherAssistant"
@@ -66,6 +67,7 @@ function getNavItems(user: User | null): NavItem[] {
   // companyOwner manages companies and fairs at the org level
   const companyOwnerItems: NavItem[] = [
     { label: "Manage Companies", path: "/companies", icon: <ShareIcon /> },
+    { label: "Fair announcements", path: "/dashboard/fair-announcements", icon: <CampaignIcon /> },
     { label: "Browse Booths", path: "/booths", icon: <BusinessIcon /> },
     { label: "Candidate Shortlist", path: "/dashboard/shortlist", icon: <PeopleIcon /> },
     { label: "Q&A Sessions", path: "/dashboard/qa-sessions", icon: <PresentationIcon /> },
@@ -77,12 +79,14 @@ function getNavItems(user: User | null): NavItem[] {
     ? [
         { label: "Manage Booth", path: `/company/${user.companyId}/booth`, icon: <BusinessIcon /> },
         { label: "Submissions", path: `/company/${user.companyId}/submissions`, icon: <AssignmentIcon /> },
+        { label: "Fair announcements", path: "/dashboard/fair-announcements", icon: <CampaignIcon /> },
         { label: "Browse Booths", path: "/booths", icon: <EventIcon /> },
         { label: "Candidate Shortlist", path: "/dashboard/shortlist", icon: <PeopleIcon /> },
         { label: "Q&A Sessions", path: "/dashboard/qa-sessions", icon: <PresentationIcon /> },
         { label: "My 1x1 Calls", path: "/dashboard/my-calls", icon: <VideoCallIcon /> },
       ]
     : [
+        { label: "Fair announcements", path: "/dashboard/fair-announcements", icon: <CampaignIcon /> },
         { label: "Browse Booths", path: "/booths", icon: <BusinessIcon /> },
       ]
 

--- a/frontend/src/components/FairAnnouncementsBanner.tsx
+++ b/frontend/src/components/FairAnnouncementsBanner.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState, useCallback } from "react"
+import { Link as RouterLink } from "react-router-dom"
+import { Box, Typography, IconButton, Paper, Link } from "@mui/material"
+import { alpha } from "@mui/material/styles"
+import CloseIcon from "@mui/icons-material/Close"
+import CampaignIcon from "@mui/icons-material/Campaign"
+import { waitForFirebaseUser } from "../firebase"
+import { API_URL } from "../config"
+import type { User } from "../utils/auth"
+
+const DISMISS_PREFIX = "fairAnnouncementDismissed:"
+
+type FairAnnouncementItem = {
+  id: string
+  fairId: string
+  fairName: string | null
+  title: string
+  description: string
+  published: boolean
+  publishedAt: number | null
+  fairStartTime?: number | null
+  fairEndTime?: number | null
+}
+
+export default function FairAnnouncementsBanner({
+  user,
+}: Readonly<{
+  user: User | null
+}>) {
+  const [items, setItems] = useState<FairAnnouncementItem[]>([])
+
+  const dismissStorageKey = useCallback(
+    (announcementId: string) => `${DISMISS_PREFIX}${user?.uid ?? ""}:${announcementId}`,
+    [user?.uid],
+  )
+
+  const load = useCallback(async () => {
+    if (!user?.uid) return
+    if (user.role !== "companyOwner" && user.role !== "representative") return
+    if (!user.companyId) return
+    try {
+      const firebaseUser = await waitForFirebaseUser()
+      if (!firebaseUser) return
+      const token = await firebaseUser.getIdToken()
+      if (!token) return
+      const res = await fetch(`${API_URL}/api/fairs/my-announcements`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) return
+      const data = await res.json()
+      const list: FairAnnouncementItem[] = data.announcements || []
+      const filtered = list.filter((a) => {
+        try {
+          return globalThis.localStorage.getItem(dismissStorageKey(a.id)) !== "1"
+        } catch {
+          return true
+        }
+      })
+      setItems(filtered)
+    } catch {
+      /* ignore */
+    }
+  }, [user?.uid, user?.role, user?.companyId, dismissStorageKey])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const dismiss = (announcementId: string) => {
+    try {
+      globalThis.localStorage.setItem(dismissStorageKey(announcementId), "1")
+    } catch {
+      /* ignore */
+    }
+    setItems((prev) => prev.filter((a) => a.id !== announcementId))
+  }
+
+  if (!user || items.length === 0) return null
+
+  return (
+    <Box sx={{ mb: 3, width: "100%" }}>
+      {items.map((a) => (
+        <Paper
+          key={`${a.fairId}-${a.id}`}
+          elevation={0}
+          sx={{
+            mb: 1,
+            p: 1.5,
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1,
+            border: (theme) => `1px solid ${alpha(theme.palette.warning.main, 0.28)}`,
+            bgcolor: (theme) => alpha(theme.palette.warning.main, 0.14),
+            "&:last-of-type": { mb: 0 },
+          }}
+        >
+          <CampaignIcon sx={{ color: "warning.dark", mt: 0.25, flexShrink: 0 }} />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "#1a1a1a" }}>
+              {a.title}
+            </Typography>
+            {a.fairName ? (
+              <Link
+                component={RouterLink}
+                to={`/fair/${a.fairId}`}
+                variant="caption"
+                sx={{
+                  display: "block",
+                  mt: 0.25,
+                  fontWeight: 600,
+                  color: "warning.dark",
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
+                {a.fairName}
+              </Link>
+            ) : null}
+            {a.description.trim() ? (
+              <Typography variant="body2" sx={{ mt: 1, color: "text.primary" }}>
+                {a.description}
+              </Typography>
+            ) : null}
+          </Box>
+          <IconButton
+            size="small"
+            aria-label="Dismiss announcement"
+            onClick={() => dismiss(a.id)}
+            sx={{ flexShrink: 0 }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Paper>
+      ))}
+    </Box>
+  )
+}

--- a/frontend/src/components/__tests__/BaseLayout.test.tsx
+++ b/frontend/src/components/__tests__/BaseLayout.test.tsx
@@ -240,6 +240,7 @@ describe("BaseLayout", () => {
       )
       await openDrawer()
       expect(screen.getByText("Manage Companies")).toBeInTheDocument()
+      expect(screen.getByText("Fair announcements")).toBeInTheDocument()
       expect(screen.getByText("Browse Booths")).toBeInTheDocument()
     })
 

--- a/frontend/src/components/__tests__/FairAnnouncementsBanner.test.tsx
+++ b/frontend/src/components/__tests__/FairAnnouncementsBanner.test.tsx
@@ -1,0 +1,168 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { BrowserRouter } from "react-router-dom"
+import FairAnnouncementsBanner from "../FairAnnouncementsBanner"
+import * as firebase from "../../firebase"
+
+vi.mock("../../firebase", () => ({
+  waitForFirebaseUser: vi.fn(),
+}))
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
+}))
+
+describe("FairAnnouncementsBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.localStorage.clear()
+    globalThis.fetch = vi.fn()
+    vi.mocked(firebase.waitForFirebaseUser).mockResolvedValue({
+      getIdToken: vi.fn().mockResolvedValue("banner-token"),
+    } as any)
+  })
+
+  const ownerUser = {
+    uid: "uid-1",
+    email: "o@example.com",
+    role: "companyOwner" as const,
+    companyId: "comp-1",
+  }
+
+  it("loads announcements from API and filters out dismissed ids (localStorage)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        announcements: [
+          {
+            id: "ann-1",
+            fairId: "f1",
+            fairName: "Fair A",
+            title: "Hello",
+            description: "Body",
+            published: true,
+            publishedAt: Date.now(),
+          },
+          {
+            id: "ann-2",
+            fairId: "f2",
+            fairName: "Fair B",
+            title: "Stay",
+            description: "",
+            published: true,
+            publishedAt: Date.now(),
+          },
+        ],
+      }),
+    } as Response)
+
+    globalThis.localStorage.setItem("fairAnnouncementDismissed:uid-1:ann-1", "1")
+
+    render(
+      <BrowserRouter>
+        <FairAnnouncementsBanner user={ownerUser} />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Stay")).toBeInTheDocument()
+    })
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument()
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/api/fairs/my-announcements",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer banner-token" },
+      }),
+    )
+  })
+
+  it("shows all items when localStorage getItem throws during filter", async () => {
+    const spy = vi.spyOn(globalThis.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("blocked")
+    })
+
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        announcements: [
+          {
+            id: "ann-x",
+            fairId: "f1",
+            fairName: "Fair",
+            title: "Shown",
+            description: "D",
+            published: true,
+            publishedAt: Date.now(),
+          },
+        ],
+      }),
+    } as Response)
+
+    render(
+      <BrowserRouter>
+        <FairAnnouncementsBanner user={ownerUser} />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Shown")).toBeInTheDocument()
+    })
+
+    spy.mockRestore()
+  })
+
+  it("returns null when fetch is not ok", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    } as Response)
+
+    const { container } = render(
+      <BrowserRouter>
+        <FairAnnouncementsBanner user={ownerUser} />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector(".MuiPaper-root")).toBeNull()
+    })
+  })
+
+  it("dismisses an announcement and removes it from the list", async () => {
+    const user = userEvent.setup()
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        announcements: [
+          {
+            id: "ann-d",
+            fairId: "f1",
+            fairName: "Fair",
+            title: "Dismiss me",
+            description: "",
+            published: true,
+            publishedAt: Date.now(),
+          },
+        ],
+      }),
+    } as Response)
+
+    render(
+      <BrowserRouter>
+        <FairAnnouncementsBanner user={ownerUser} />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByText("Dismiss me")).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /dismiss announcement/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Dismiss me")).not.toBeInTheDocument()
+    })
+    expect(globalThis.localStorage.getItem("fairAnnouncementDismissed:uid-1:ann-d")).toBe("1")
+  })
+})

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -1,7 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from "firebase/app";
 
-import { getAuth, GoogleAuthProvider } from "firebase/auth"; // ✅ added GoogleAuthProvider
+import { getAuth, GoogleAuthProvider, onAuthStateChanged, type User } from "firebase/auth"; // ✅ added GoogleAuthProvider
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
@@ -17,6 +17,22 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
+
+/** Resolves when Firebase has restored `currentUser` (or null after timeout). Use before token calls after navigation. */
+export function waitForFirebaseUser(): Promise<User | null> {
+  if (auth.currentUser) return Promise.resolve(auth.currentUser);
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), 5000);
+    const unsub = onAuthStateChanged(auth, (u) => {
+      if (u) {
+        clearTimeout(timer);
+        unsub();
+        resolve(u);
+      }
+    });
+  });
+}
+
 export const storage = getStorage(app);
 export const db = getFirestore(app);
 export const googleProvider = new GoogleAuthProvider(); // ✅ added this line

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import VideoCallIcon from "@mui/icons-material/VideoCall"
 import GroupsIcon from "@mui/icons-material/Groups"
 import EventList from "../components/EventList"
 import BaseLayout from "../components/BaseLayout"
+import FairAnnouncementsBanner from "../components/FairAnnouncementsBanner"
 
 // Helper function to get fair status message based on user role
 function getFairStatusMessage(role: string | undefined): string {
@@ -848,8 +849,9 @@ export default function Dashboard() {
 
   return (
     <BaseLayout>
-      <Container maxWidth="lg">
-        <Box sx={{ py: 6 }}>
+      <Container maxWidth="lg" sx={{ pt: 3 }}>
+        <FairAnnouncementsBanner user={user} />
+        <Box sx={{ pb: 6 }}>
           {/* Welcome Section */}
           <Box
             sx={{

--- a/frontend/src/pages/FairAdminDashboard.tsx
+++ b/frontend/src/pages/FairAdminDashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@mui/material"
 import DeleteIcon from "@mui/icons-material/Delete"
 import AddIcon from "@mui/icons-material/Add"
+import EditIcon from "@mui/icons-material/Edit"
 import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import RefreshIcon from "@mui/icons-material/Refresh"
 import BaseLayout from "../components/BaseLayout"
@@ -38,6 +39,19 @@ import { authUtils } from "../utils/auth"
 import { auth } from "../firebase"
 import { API_URL } from "../config"
 import { useGeocodeSuggest } from "../hooks/useGeocodeSuggest"
+
+type FairAnnouncementRow = {
+  id: string
+  fairId: string
+  fairName: string | null
+  title: string
+  description: string
+  published: boolean
+  publishedAt: number | null
+  createdAt: number | null
+  updatedAt: number | null
+  createdBy: string | null
+}
 
 function formatSavedHubLine(fair: {
   venueCity?: string | null
@@ -100,6 +114,15 @@ export default function FairAdminDashboard() {
   const [codeCopied, setCodeCopied] = useState(false)
   const [refreshingInviteCode, setRefreshingInviteCode] = useState(false)
 
+  const [announcements, setAnnouncements] = useState<FairAnnouncementRow[]>([])
+  const [loadingAnnouncements, setLoadingAnnouncements] = useState(true)
+  const [annDialogOpen, setAnnDialogOpen] = useState(false)
+  const [editingAnnId, setEditingAnnId] = useState<string | null>(null)
+  const [annForm, setAnnForm] = useState({ title: "", description: "", published: false })
+  const [annSaving, setAnnSaving] = useState(false)
+  const [annError, setAnnError] = useState("")
+  const [publishingAnnId, setPublishingAnnId] = useState<string | null>(null)
+
   useEffect(() => {
     if (user?.role !== "administrator") {
       navigate("/dashboard")
@@ -107,6 +130,7 @@ export default function FairAdminDashboard() {
     }
     if (!fairLoading && fairId) {
       loadEnrollments()
+      loadAnnouncements()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fairLoading, fairId, navigate])
@@ -161,6 +185,133 @@ export default function FairAdminDashboard() {
       console.error(err)
     } finally {
       setLoadingEnrollments(false)
+    }
+  }
+
+  const loadAnnouncements = async () => {
+    if (!fairId) return
+    try {
+      setLoadingAnnouncements(true)
+      const token = await getToken()
+      const res = await fetch(`${API_URL}/api/fairs/${fairId}/announcements`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error("Failed to load announcements")
+      const data = await res.json()
+      setAnnouncements(data.announcements || [])
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoadingAnnouncements(false)
+    }
+  }
+
+  const openCreateAnnouncement = () => {
+    setEditingAnnId(null)
+    setAnnForm({ title: "", description: "", published: false })
+    setAnnError("")
+    setAnnDialogOpen(true)
+  }
+
+  const openEditAnnouncement = (row: FairAnnouncementRow) => {
+    setEditingAnnId(row.id)
+    setAnnForm({
+      title: row.title,
+      description: row.description,
+      published: row.published,
+    })
+    setAnnError("")
+    setAnnDialogOpen(true)
+  }
+
+  const submitAnnouncement = async (mode: "create-draft" | "create-publish" | "save-edit") => {
+    if (!fairId || !annForm.title.trim()) {
+      setAnnError("Title is required")
+      return
+    }
+    let published = annForm.published
+    if (mode === "create-publish") published = true
+    if (mode === "create-draft") published = false
+
+    setAnnSaving(true)
+    setAnnError("")
+    try {
+      const token = await getToken()
+      const body: Record<string, unknown> = {
+        title: annForm.title.trim(),
+        published,
+      }
+      const desc = annForm.description.trim()
+      if (desc) body.description = desc
+      else if (editingAnnId) body.description = ""
+
+      if (editingAnnId) {
+        const res = await fetch(`${API_URL}/api/fairs/${fairId}/announcements/${editingAnnId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify(body),
+        })
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error(typeof data.error === "string" ? data.error : "Failed to update announcement")
+      } else {
+        const res = await fetch(`${API_URL}/api/fairs/${fairId}/announcements`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            title: annForm.title.trim(),
+            ...(desc ? { description: desc } : {}),
+            published,
+          }),
+        })
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error(typeof data.error === "string" ? data.error : "Failed to create announcement")
+      }
+      setAnnDialogOpen(false)
+      setSuccess(editingAnnId ? "Announcement updated" : "Announcement saved")
+      await loadAnnouncements()
+    } catch (err: any) {
+      setAnnError(err.message || "Save failed")
+    } finally {
+      setAnnSaving(false)
+    }
+  }
+
+  const handleDeleteAnnouncement = async (announcementId: string) => {
+    if (!fairId) return
+    if (!globalThis.confirm("Delete this announcement?")) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`${API_URL}/api/fairs/${fairId}/announcements/${announcementId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error("Failed to delete")
+      setSuccess("Announcement deleted")
+      await loadAnnouncements()
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  const handlePublishAnnouncement = async (row: FairAnnouncementRow) => {
+    if (!fairId || row.published) return
+    setPublishingAnnId(row.id)
+    setError("")
+    try {
+      const token = await getToken()
+      const res = await fetch(`${API_URL}/api/fairs/${fairId}/announcements/${row.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ published: true }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(typeof data.error === "string" ? data.error : "Failed to publish")
+      setSuccess("Announcement published")
+      await loadAnnouncements()
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setPublishingAnnId(null)
     }
   }
 
@@ -483,6 +634,90 @@ export default function FairAdminDashboard() {
             </Card>
           </Grid>
 
+          {/* Fair announcements (employer banners) */}
+          <Grid size={{ xs: 12 }}>
+            <Card>
+              <CardContent>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+                  <Typography variant="h6">Fair announcements</Typography>
+                  <Button variant="contained" startIcon={<AddIcon />} onClick={openCreateAnnouncement}>
+                    New announcement
+                  </Button>
+                </Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Published announcements appear as banners for company owners and representatives whose company is
+                  enrolled in this fair.
+                </Typography>
+                {loadingAnnouncements && <CircularProgress size={24} />}
+                {!loadingAnnouncements && announcements.length === 0 && (
+                  <Typography color="text.secondary">No announcements yet.</Typography>
+                )}
+                {!loadingAnnouncements && announcements.length > 0 && (
+                  <TableContainer component={Paper} variant="outlined">
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Title</TableCell>
+                          <TableCell>Description</TableCell>
+                          <TableCell>Status</TableCell>
+                          <TableCell align="right">Actions</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {announcements.map((row) => (
+                          <TableRow key={row.id}>
+                            <TableCell sx={{ fontWeight: 600, maxWidth: 220 }}>
+                              {row.title}
+                            </TableCell>
+                            <TableCell sx={{ maxWidth: 360 }}>
+                              <Typography variant="body2" noWrap title={row.description || undefined}>
+                                {row.description || "—"}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              <Chip
+                                size="small"
+                                label={row.published ? "Published" : "Draft"}
+                                color={row.published ? "success" : "default"}
+                                variant={row.published ? "filled" : "outlined"}
+                              />
+                            </TableCell>
+                            <TableCell align="right">
+                              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, flexWrap: "wrap", justifyContent: "flex-end" }}>
+                                {!row.published ? (
+                                  <Button
+                                    size="small"
+                                    variant="outlined"
+                                    color="success"
+                                    disabled={publishingAnnId === row.id}
+                                    onClick={() => void handlePublishAnnouncement(row)}
+                                  >
+                                    {publishingAnnId === row.id ? "Publishing…" : "Publish"}
+                                  </Button>
+                                ) : null}
+                                <IconButton size="small" onClick={() => openEditAnnouncement(row)} title="Edit">
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => handleDeleteAnnouncement(row.id)}
+                                  title="Delete"
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Box>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+
           {/* Enrolled Companies */}
           <Grid size={{ xs: 12 }}>
             <Card>
@@ -674,6 +909,89 @@ export default function FairAdminDashboard() {
             <Button type="submit" variant="contained" disabled={saving || !editForm.name.trim()}>
               {saving ? "Saving..." : "Save"}
             </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+
+      {/* Announcement create/edit */}
+      <Dialog
+        open={annDialogOpen}
+        onClose={() => !annSaving && setAnnDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>{editingAnnId ? "Edit announcement" : "New announcement"}</DialogTitle>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            void submitAnnouncement(editingAnnId ? "save-edit" : "create-publish")
+          }}
+        >
+          <DialogContent>
+            <TextField
+              label="Title"
+              value={annForm.title}
+              onChange={(e) => setAnnForm((f) => ({ ...f, title: e.target.value }))}
+              fullWidth
+              required
+              sx={{ mt: 1, mb: 2 }}
+            />
+            <TextField
+              label="Description (optional)"
+              value={annForm.description}
+              onChange={(e) => setAnnForm((f) => ({ ...f, description: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={3}
+              sx={{ mb: 2 }}
+              placeholder="Add more context for employers…"
+            />
+            {editingAnnId ? (
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={annForm.published}
+                    onChange={(e) => setAnnForm((f) => ({ ...f, published: e.target.checked }))}
+                    color="success"
+                  />
+                }
+                label={annForm.published ? "Published" : "Draft"}
+              />
+            ) : null}
+            {annError ? <Alert severity="error" sx={{ mt: 1 }}>{annError}</Alert> : null}
+          </DialogContent>
+          <DialogActions sx={{ flexWrap: "wrap", gap: 1 }}>
+            <Button type="button" onClick={() => setAnnDialogOpen(false)} disabled={annSaving}>
+              Cancel
+            </Button>
+            {editingAnnId ? (
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={annSaving}
+              >
+                {annSaving ? "Saving…" : "Save changes"}
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  variant="outlined"
+                  disabled={annSaving}
+                  onClick={() => void submitAnnouncement("create-draft")}
+                >
+                  Save draft
+                </Button>
+                <Button
+                  type="button"
+                  variant="contained"
+                  disabled={annSaving}
+                  onClick={() => void submitAnnouncement("create-publish")}
+                >
+                  Publish
+                </Button>
+              </>
+            )}
           </DialogActions>
         </form>
       </Dialog>

--- a/frontend/src/pages/FairAnnouncementsPage.tsx
+++ b/frontend/src/pages/FairAnnouncementsPage.tsx
@@ -1,0 +1,233 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
+import { Link as RouterLink } from "react-router-dom"
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Container,
+  Link,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material"
+import CampaignIcon from "@mui/icons-material/Campaign"
+import BaseLayout from "../components/BaseLayout"
+import { API_URL } from "../config"
+import { waitForFirebaseUser } from "../firebase"
+import { authUtils } from "../utils/auth"
+
+type AnnouncementRow = {
+  id: string
+  fairId: string
+  fairName: string | null
+  title: string
+  description: string
+  publishedAt: number | null
+  createdAt: number | null
+  fairStartTime: number | null
+  fairEndTime: number | null
+}
+
+function formatTs(ms: number | null): string {
+  if (ms == null) return "—"
+  try {
+    return new Date(ms).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })
+  } catch {
+    return "—"
+  }
+}
+
+function fairWindowLabel(start: number | null, end: number | null): string {
+  if (start == null && end == null) return "—"
+  const a = formatTs(start)
+  const b = formatTs(end)
+  if (start != null && end != null) return `${a} – ${b}`
+  if (end != null) return `Ends ${b}`
+  return `Starts ${a}`
+}
+
+function isPastFair(r: AnnouncementRow, now: number): boolean {
+  return r.fairEndTime != null && r.fairEndTime < now
+}
+
+function AnnouncementTable(props: Readonly<{ rows: AnnouncementRow[]; emptyHint: string }>) {
+  const { rows, emptyHint } = props
+  if (rows.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+        {emptyHint}
+      </Typography>
+    )
+  }
+
+  const now = Date.now()
+
+  return (
+    <TableContainer component={Paper} elevation={0} sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ bgcolor: "action.hover" }}>
+            <TableCell>Fair</TableCell>
+            <TableCell>Announcement</TableCell>
+            <TableCell sx={{ whiteSpace: "nowrap" }}>Published</TableCell>
+            <TableCell>Fair dates</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((r) => (
+            <TableRow key={`${r.fairId}-${r.id}`} hover>
+              <TableCell sx={{ verticalAlign: "top" }}>
+                <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.75 }}>
+                  <Link component={RouterLink} to={`/fair/${r.fairId}`} fontWeight={600} underline="hover">
+                    {r.fairName || r.fairId}
+                  </Link>
+                  {isPastFair(r, now) ? (
+                    <Chip size="small" label="Past fair" variant="outlined" sx={{ height: 22 }} />
+                  ) : (
+                    <Chip size="small" label="Active / upcoming" color="success" variant="outlined" sx={{ height: 22 }} />
+                  )}
+                </Box>
+              </TableCell>
+              <TableCell sx={{ verticalAlign: "top", maxWidth: 360 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                  {r.title}
+                </Typography>
+                {r.description.trim() ? (
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, whiteSpace: "pre-wrap" }}>
+                    {r.description}
+                  </Typography>
+                ) : null}
+              </TableCell>
+              <TableCell sx={{ verticalAlign: "top", whiteSpace: "nowrap" }}>{formatTs(r.publishedAt)}</TableCell>
+              <TableCell sx={{ verticalAlign: "top", color: "text.secondary", fontSize: "0.875rem" }}>
+                {fairWindowLabel(r.fairStartTime, r.fairEndTime)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default function FairAnnouncementsPage() {
+  const user = authUtils.getCurrentUser()
+  const [rows, setRows] = useState<AnnouncementRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const canUsePage =
+    user && (user.role === "companyOwner" || user.role === "representative")
+
+  const load = useCallback(async () => {
+    if (!user?.uid || !canUsePage) {
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const firebaseUser = await waitForFirebaseUser()
+      if (!firebaseUser) {
+        setError("Could not verify your session. Try refreshing the page.")
+        return
+      }
+      const token = await firebaseUser.getIdToken()
+      const res = await fetch(`${API_URL}/api/fairs/my-announcements`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        setError("Could not load announcements.")
+        return
+      }
+      const data = await res.json()
+      setRows(data.announcements || [])
+    } catch {
+      setError("Could not load announcements.")
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.uid, canUsePage])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const { pastRows, activeRows } = useMemo(() => {
+    const t = Date.now()
+    const past: AnnouncementRow[] = []
+    const active: AnnouncementRow[] = []
+    for (const r of rows) {
+      if (isPastFair(r, t)) past.push(r)
+      else active.push(r)
+    }
+    return { pastRows: past, activeRows: active }
+  }, [rows])
+
+  if (!user) return null
+
+  let mainContent: ReactNode
+  if (!canUsePage) {
+    mainContent = <Alert severity="info">This page is available to company owners and representatives.</Alert>
+  } else if (loading) {
+    mainContent = (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <CircularProgress />
+      </Box>
+    )
+  } else if (error) {
+    mainContent = <Alert severity="error">{error}</Alert>
+  } else if (rows.length === 0) {
+    mainContent = (
+      <Paper elevation={0} sx={{ p: 3, border: "1px solid", borderColor: "divider", borderRadius: 2 }}>
+        <Typography variant="body1" color="text.secondary">
+          No published announcements yet for your enrolled fairs.
+        </Typography>
+      </Paper>
+    )
+  } else {
+    mainContent = (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 1.5 }}>
+            Upcoming and current fairs
+          </Typography>
+          <AnnouncementTable rows={activeRows} emptyHint="None in this section." />
+        </Box>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 1.5 }}>
+            Past fairs
+          </Typography>
+          <AnnouncementTable rows={pastRows} emptyHint="No announcements from past fairs yet." />
+        </Box>
+      </Box>
+    )
+  }
+
+  return (
+    <BaseLayout pageTitle="Fair announcements">
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Box sx={{ mb: 3, display: "flex", alignItems: "flex-start", gap: 1.5 }}>
+          <CampaignIcon sx={{ color: "warning.dark", mt: 0.5 }} />
+          <Box>
+            <Typography variant="h4" sx={{ fontWeight: 700, color: "#1a1a1a", mb: 0.5 }}>
+              Fair announcements
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Published announcements for career fairs your company is enrolled in. This list includes older fairs and
+              announcements you may have closed on the dashboard.
+            </Typography>
+          </Box>
+        </Box>
+
+        {mainContent}
+      </Container>
+    </BaseLayout>
+  )
+}

--- a/frontend/src/pages/FairLanding.tsx
+++ b/frontend/src/pages/FairLanding.tsx
@@ -13,6 +13,11 @@ import {
   DialogContent,
   DialogActions,
   TextField,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
 } from "@mui/material"
 import EventIcon from "@mui/icons-material/Event"
 import LocationOnIcon from "@mui/icons-material/LocationOn"
@@ -22,8 +27,9 @@ import ForumIcon from "@mui/icons-material/Forum"
 import BaseLayout from "../components/BaseLayout"
 import { useFair } from "../contexts/FairContext"
 import { authUtils } from "../utils/auth"
-import { auth } from "../firebase"
+import { waitForFirebaseUser } from "../firebase"
 import { API_URL } from "../config"
+import { fetchOwnedCompaniesForUser, type OwnedCompanySummary } from "../utils/ownedCompanies"
 
 function formatDate(ms: number | null): string {
   if (!ms) return "TBD"
@@ -41,6 +47,10 @@ export default function FairLanding() {
   const [joinSuccess, setJoinSuccess] = useState(false)
   const [enrollmentLoading, setEnrollmentLoading] = useState(false)
   const [isEnrolled, setIsEnrolled] = useState(false)
+  /** Which company is enrolled in the current fair (for owners with multiple companies). */
+  const [enrolledCompanyId, setEnrolledCompanyId] = useState<string | null>(null)
+  const [ownedCompanies, setOwnedCompanies] = useState<OwnedCompanySummary[]>([])
+  const [joinCompanyId, setJoinCompanyId] = useState("")
   const [leaveDialogOpen, setLeaveDialogOpen] = useState(false)
   const [leaving, setLeaving] = useState(false)
   const [leaveError, setLeaveError] = useState("")
@@ -54,7 +64,9 @@ export default function FairLanding() {
     async function loadEnrollment() {
       setEnrollmentLoading(true)
       try {
-        const token = await auth.currentUser?.getIdToken()
+        const firebaseUser = await waitForFirebaseUser()
+        if (!firebaseUser) return
+        const token = await firebaseUser.getIdToken()
         if (!token) return
         const res = await fetch(`${API_URL}/api/fairs/my-enrollments`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -62,8 +74,11 @@ export default function FairLanding() {
         const data = await res.json()
         if (!res.ok) throw new Error(data.error || "Failed to load enrollments")
 
-        const entry = (data.enrollments || []).find((e: { fairId: string }) => e.fairId === fairId)
+        const entry = (data.enrollments || []).find((e: { fairId: string }) => e.fairId === fairId) as
+          | { fairId: string; companyId?: string }
+          | undefined
         setIsEnrolled(!!entry)
+        setEnrolledCompanyId(entry?.companyId ?? null)
       } catch (err) {
         console.error("Error loading enrollment:", err)
       } finally {
@@ -74,29 +89,65 @@ export default function FairLanding() {
     loadEnrollment()
   }, [fairId, isCompanyUser])
 
+  useEffect(() => {
+    if (!joinDialogOpen || user?.role !== "companyOwner" || !user?.uid) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const list = await fetchOwnedCompaniesForUser(user.uid)
+        if (cancelled) return
+        setOwnedCompanies(list)
+        if (list.length === 1) setJoinCompanyId(list[0].id)
+        else setJoinCompanyId("")
+      } catch {
+        if (!cancelled) setOwnedCompanies([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [joinDialogOpen, user?.role, user?.uid])
+
   const handleJoinFair = async () => {
     if (!inviteCode.trim()) return
+    if (user?.role === "companyOwner" && ownedCompanies.length > 1 && !joinCompanyId) {
+      setJoinError("Select which company is joining this fair.")
+      return
+    }
     setJoining(true)
     setJoinError("")
     try {
-      const token = await auth.currentUser?.getIdToken()
+      const firebaseUser = await waitForFirebaseUser()
+      if (!firebaseUser) throw new Error("Not signed in.")
+      const token = await firebaseUser.getIdToken()
+      const body: { inviteCode: string; companyId?: string } = {
+        inviteCode: inviteCode.trim().toUpperCase(),
+      }
+      if (user?.role === "companyOwner") {
+        if (ownedCompanies.length > 1) body.companyId = joinCompanyId
+        else if (ownedCompanies.length === 1) body.companyId = ownedCompanies[0].id
+      }
       const res = await fetch(`${API_URL}/api/fairs/${fairId}/enroll`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ inviteCode: inviteCode.trim().toUpperCase() }),
+        body: JSON.stringify(body),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || "Failed to join fair")
+      const navCompanyId =
+        user?.role === "companyOwner"
+          ? body.companyId || ownedCompanies[0]?.id || user?.companyId
+          : user?.companyId || undefined
       setJoinSuccess(true)
       setLeaveSuccess(false)
       setIsEnrolled(true)
+      setEnrolledCompanyId(navCompanyId ?? null)
       setJoinDialogOpen(false)
-      // Navigate to the fair-scoped booth editor using the resolved fairId from the response
-      if (data.boothId && user?.companyId) {
-        navigate(`/fair/${data.fairId || fairId}/company/${user.companyId}/booth`)
+      if (data.boothId && navCompanyId) {
+        navigate(`/fair/${data.fairId || fairId}/company/${navCompanyId}/booth`)
       }
     } catch (err: any) {
       setJoinError(err.message)
@@ -110,15 +161,22 @@ export default function FairLanding() {
     setLeaving(true)
     setLeaveError("")
     try {
-      const token = await auth.currentUser?.getIdToken()
+      const firebaseUser = await waitForFirebaseUser()
+      if (!firebaseUser) throw new Error("Not signed in.")
+      const token = await firebaseUser.getIdToken()
       const res = await fetch(`${API_URL}/api/fairs/${fairId}/leave`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(enrolledCompanyId ? { companyId: enrolledCompanyId } : {}),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || "Failed to leave fair")
 
       setIsEnrolled(false)
+      setEnrolledCompanyId(null)
       setLeaveSuccess(true)
       setJoinSuccess(false)
       setLeaveDialogOpen(false)
@@ -235,12 +293,34 @@ export default function FairLanding() {
         </Box>
       </Container>
 
-      <Dialog open={joinDialogOpen} onClose={() => setJoinDialogOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog
+        open={joinDialogOpen}
+        onClose={() => {
+          setJoinDialogOpen(false)
+          setJoinCompanyId("")
+          setOwnedCompanies([])
+        }}
+        maxWidth="sm"
+        fullWidth
+      >
         <DialogTitle>Join Career Fair</DialogTitle>
         <DialogContent>
           <Typography color="text.secondary" sx={{ mb: 2 }}>
             Enter the fair invite code provided by the event organizer.
           </Typography>
+          {user?.role === "companyOwner" && ownedCompanies.length > 1 && (
+            <FormControl sx={{ mb: 2 }} component="fieldset" variant="standard" fullWidth>
+              <FormLabel component="legend">Company enrolling in this fair</FormLabel>
+              <RadioGroup
+                value={joinCompanyId}
+                onChange={(e) => setJoinCompanyId(e.target.value)}
+              >
+                {ownedCompanies.map((c) => (
+                  <FormControlLabel key={c.id} value={c.id} control={<Radio />} label={c.companyName} />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          )}
           <TextField
             label="Fair Invite Code"
             value={inviteCode}
@@ -251,8 +331,24 @@ export default function FairLanding() {
           {joinError && <Alert severity="error" sx={{ mt: 2 }}>{joinError}</Alert>}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setJoinDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleJoinFair} disabled={joining || !inviteCode.trim()}>
+          <Button
+            onClick={() => {
+              setJoinDialogOpen(false)
+              setJoinCompanyId("")
+              setOwnedCompanies([])
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleJoinFair}
+            disabled={
+              joining ||
+              !inviteCode.trim() ||
+              (user?.role === "companyOwner" && ownedCompanies.length > 1 && !joinCompanyId)
+            }
+          >
             {joining ? "Joining..." : "Join Fair"}
           </Button>
         </DialogActions>

--- a/frontend/src/pages/FairList.tsx
+++ b/frontend/src/pages/FairList.tsx
@@ -330,7 +330,7 @@ export default function FairList() {
           headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) {
-          console.error("loadEnrollments: API returned", res.status, await res.text().catch(() => ""))
+          console.error("loadEnrollments: request failed", res.status)
           return
         }
         const data = await res.json()

--- a/frontend/src/pages/FairList.tsx
+++ b/frontend/src/pages/FairList.tsx
@@ -19,11 +19,15 @@ import {
   TextField,
   Autocomplete,
   FormControl,
+  FormLabel,
   InputLabel,
   Select,
   MenuItem,
   ToggleButton,
   ToggleButtonGroup,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
 } from "@mui/material"
 import { alpha } from "@mui/material/styles"
 import EventIcon from "@mui/icons-material/Event"
@@ -39,6 +43,7 @@ import { API_URL } from "../config"
 import { authUtils } from "../utils/auth"
 import { auth } from "../firebase"
 import { useGeocodeSuggest } from "../hooks/useGeocodeSuggest"
+import { fetchOwnedCompaniesForUser, type OwnedCompanySummary } from "../utils/ownedCompanies"
 
 function waitForFirebaseUser(): Promise<typeof auth.currentUser> {
   if (auth.currentUser) return Promise.resolve(auth.currentUser)
@@ -112,14 +117,18 @@ export default function FairList() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
 
-  // enrolledMap: fairId → boothId (null if enrolled but no booth yet)
-  const [enrolledMap, setEnrolledMap] = useState<Record<string, string | null>>({})
+  // fairId → enrollment details (companyId required for booth URL and leave)
+  const [enrolledByFair, setEnrolledByFair] = useState<
+    Record<string, { boothId: string | null; companyId: string }>
+  >({})
 
   // Join dialog state
   const [joinDialogFairId, setJoinDialogFairId] = useState<string | null>(null)
   const [inviteCode, setInviteCode] = useState("")
   const [joining, setJoining] = useState(false)
   const [joinError, setJoinError] = useState("")
+  const [joinCompanyId, setJoinCompanyId] = useState("")
+  const [ownedCompaniesForJoin, setOwnedCompaniesForJoin] = useState<OwnedCompanySummary[]>([])
 
   // Leave dialog state
   const [leaveDialogFairId, setLeaveDialogFairId] = useState<string | null>(null)
@@ -325,49 +334,95 @@ export default function FairList() {
           return
         }
         const data = await res.json()
-        const map: Record<string, string | null> = {}
+        const map: Record<string, { boothId: string | null; companyId: string }> = {}
         for (const e of data.enrollments || []) {
-          map[e.fairId] = e.boothId
+          const cid = e.companyId || user?.companyId
+          if (e.fairId && cid) {
+            map[e.fairId] = { boothId: e.boothId ?? null, companyId: cid }
+          }
         }
-        setEnrolledMap(map)
+        setEnrolledByFair(map)
       } catch (err) {
         console.error("Error loading enrollments:", err)
       }
     }
     loadEnrollments()
-  }, [isCompanyUser])
+  }, [isCompanyUser, user?.companyId])
+
+  useEffect(() => {
+    if (!joinDialogFairId || user?.role !== "companyOwner" || !user?.uid) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const list = await fetchOwnedCompaniesForUser(user.uid)
+        if (cancelled) return
+        setOwnedCompaniesForJoin(list)
+        if (list.length === 1) setJoinCompanyId(list[0].id)
+        else setJoinCompanyId("")
+      } catch {
+        if (!cancelled) setOwnedCompaniesForJoin([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [joinDialogFairId, user?.role, user?.uid])
 
   const handleOpenJoinDialog = (fairId: string) => {
     setJoinDialogFairId(fairId)
     setInviteCode("")
     setJoinError("")
+    setJoinCompanyId("")
   }
 
   const handleCloseJoinDialog = () => {
     setJoinDialogFairId(null)
     setInviteCode("")
     setJoinError("")
+    setJoinCompanyId("")
+    setOwnedCompaniesForJoin([])
   }
 
   const handleJoinFair = async () => {
     if (!inviteCode.trim() || !joinDialogFairId) return
+    if (user?.role === "companyOwner" && ownedCompaniesForJoin.length > 1 && !joinCompanyId) {
+      setJoinError("Select which company is joining this fair.")
+      return
+    }
     setJoining(true)
     setJoinError("")
     try {
-      const token = await auth.currentUser?.getIdToken()
+      const firebaseUser = auth.currentUser ?? (await waitForFirebaseUser())
+      if (!firebaseUser) throw new Error("Not signed in.")
+      const token = await firebaseUser.getIdToken()
+      const body: { inviteCode: string; companyId?: string } = {
+        inviteCode: inviteCode.trim().toUpperCase(),
+      }
+      if (user?.role === "companyOwner") {
+        if (ownedCompaniesForJoin.length > 1) body.companyId = joinCompanyId
+        else if (ownedCompaniesForJoin.length === 1) body.companyId = ownedCompaniesForJoin[0].id
+      }
       const res = await fetch(`${API_URL}/api/fairs/${joinDialogFairId}/enroll`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ inviteCode: inviteCode.trim().toUpperCase() }),
+        body: JSON.stringify(body),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || "Failed to join fair")
 
-      // Update local enrollment state and close dialog — user can click Edit Booth when ready
-      setEnrolledMap((prev) => ({ ...prev, [joinDialogFairId]: data.boothId || null }))
+      const resolvedCompanyId =
+        user?.role === "companyOwner"
+          ? body.companyId || ownedCompaniesForJoin[0]?.id || user?.companyId || ""
+          : user?.companyId || ""
+      if (!resolvedCompanyId) throw new Error("Could not determine company for enrollment.")
+
+      setEnrolledByFair((prev) => ({
+        ...prev,
+        [joinDialogFairId]: { boothId: data.boothId || null, companyId: resolvedCompanyId },
+      }))
       handleCloseJoinDialog()
     } catch (err: any) {
       setJoinError(err.message)
@@ -378,18 +433,25 @@ export default function FairList() {
 
   const handleLeaveFair = async () => {
     if (!leaveDialogFairId) return
+    const enc = enrolledByFair[leaveDialogFairId]
     setLeaving(true)
     setLeaveError("")
     try {
-      const token = await auth.currentUser?.getIdToken()
+      const firebaseUser = auth.currentUser ?? (await waitForFirebaseUser())
+      if (!firebaseUser) throw new Error("Not signed in.")
+      const token = await firebaseUser.getIdToken()
       const res = await fetch(`${API_URL}/api/fairs/${leaveDialogFairId}/leave`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(enc?.companyId ? { companyId: enc.companyId } : {}),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || "Failed to leave fair")
 
-      setEnrolledMap((prev) => {
+      setEnrolledByFair((prev) => {
         const next = { ...prev }
         delete next[leaveDialogFairId]
         return next
@@ -684,8 +746,9 @@ export default function FairList() {
           {displayFairs.length > 0 && displayFairs.map((fair) => {
             const status = getFairStatus(fair)
             const isEnded = fair.endTime !== null && Date.now() > fair.endTime
-            const isEnrolled = fair.id in enrolledMap
-            const boothId = enrolledMap[fair.id]
+            const isEnrolled = fair.id in enrolledByFair
+            const enc = enrolledByFair[fair.id]
+            const boothId = enc?.boothId
 
             return (
               <Grid size={{ xs: 12, sm: 6, md: 4 }} key={fair.id}>
@@ -780,8 +843,8 @@ export default function FairList() {
                             color="secondary"
                             onClick={() =>
                               navigate(
-                                boothId && user?.companyId
-                                  ? `/fair/${fair.id}/company/${user.companyId}/booth?bid=${boothId}`
+                                boothId && enc?.companyId
+                                  ? `/fair/${fair.id}/company/${enc.companyId}/booth?bid=${boothId}`
                                   : `/fair/${fair.id}`
                               )
                             }
@@ -829,6 +892,16 @@ export default function FairList() {
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
             Enter the invite code provided by the event organizer.
           </Typography>
+          {user?.role === "companyOwner" && ownedCompaniesForJoin.length > 1 && (
+            <FormControl sx={{ mb: 2 }} component="fieldset" variant="standard" fullWidth>
+              <FormLabel component="legend">Company enrolling in this fair</FormLabel>
+              <RadioGroup value={joinCompanyId} onChange={(e) => setJoinCompanyId(e.target.value)}>
+                {ownedCompaniesForJoin.map((c) => (
+                  <FormControlLabel key={c.id} value={c.id} control={<Radio />} label={c.companyName} />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          )}
           <TextField
             label="Invite Code"
             value={inviteCode}
@@ -849,7 +922,11 @@ export default function FairList() {
           <Button
             variant="contained"
             onClick={handleJoinFair}
-            disabled={joining || !inviteCode.trim()}
+            disabled={
+              joining ||
+              !inviteCode.trim() ||
+              (user?.role === "companyOwner" && ownedCompaniesForJoin.length > 1 && !joinCompanyId)
+            }
           >
             {joining ? "Joining..." : "Join Fair"}
           </Button>

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -587,10 +587,11 @@ describe("Dashboard", () => {
         </MemoryRouter>
       )
 
+      // Label "fairs enrolled" is shown even when count is still 0 (0 !== 1), so wait for the loaded count.
       await waitFor(() => {
-        expect(screen.getByText(/fairs enrolled/)).toBeInTheDocument()
+        expect(screen.getByText("2")).toBeInTheDocument()
       })
-      expect(screen.getByText("2")).toBeInTheDocument()
+      expect(screen.getByText(/fairs enrolled/)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/EmailVerificationPending.test.tsx
+++ b/frontend/src/pages/__tests__/EmailVerificationPending.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import EmailVerificationPending from "../EmailVerificationPending"
@@ -168,8 +168,12 @@ describe("EmailVerificationPending", () => {
   })
 
   it("disables verify button while loading", async () => {
-    mockVerifyAndLogin.mockImplementation(() =>
-      new Promise(resolve => setTimeout(() => resolve({ success: true }), 100))
+    let finishVerify!: (value: { success: boolean }) => void
+    mockVerifyAndLogin.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishVerify = resolve
+        })
     )
     const user = userEvent.setup()
 
@@ -184,7 +188,11 @@ describe("EmailVerificationPending", () => {
 
     await user.click(verifyButton)
 
-    // Button should be disabled during loading
-    expect(verifyButton).toBeDisabled()
+    // While loading, the primary button shows a spinner instead of label text (no accessible name).
+    await waitFor(() => {
+      expect(screen.getByRole("progressbar")).toBeInTheDocument()
+    })
+
+    finishVerify({ success: true })
   })
 })

--- a/frontend/src/pages/__tests__/FairAdminDashboard.announcements.test.tsx
+++ b/frontend/src/pages/__tests__/FairAdminDashboard.announcements.test.tsx
@@ -1,0 +1,703 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom" />
+import type { ReactNode } from "react"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { BrowserRouter } from "react-router-dom"
+import FairAdminDashboard from "../FairAdminDashboard"
+import * as authUtils from "../../utils/auth"
+import { useFair } from "../../contexts/FairContext"
+
+const mockNavigate = vi.fn()
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom")
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock("../../utils/auth", () => ({
+  authUtils: {
+    getCurrentUser: vi.fn(),
+  },
+}))
+
+vi.mock("../../contexts/FairContext", () => ({
+  useFair: vi.fn(),
+  FairProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../ProfileMenu", () => ({
+  default: () => <div data-testid="profile-menu" />,
+}))
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
+}))
+
+vi.mock("../../hooks/useGeocodeSuggest", () => ({
+  useGeocodeSuggest: () => ({ options: [], loading: false }),
+}))
+
+vi.mock("../../firebase", () => ({
+  auth: {
+    currentUser: {
+      getIdToken: vi.fn().mockResolvedValue("mock-token"),
+    },
+  },
+}))
+
+const renderFairAdminDashboard = () =>
+  render(
+    <BrowserRouter>
+      <FairAdminDashboard />
+    </BrowserRouter>,
+  )
+
+function requestUrlString(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+function mockFetchResponse(data: {
+  ok: boolean
+  status?: number
+  json: () => Promise<unknown>
+}): Promise<Response> {
+  return Promise.resolve(data as unknown as Response)
+}
+
+function parseFetchCallJsonBody(call: unknown): Record<string, unknown> {
+  expect(call).toBeDefined()
+  if (!Array.isArray(call) || call.length < 2) throw new Error("expected fetch call tuple")
+  const init = call[1] as RequestInit | undefined
+  const body = init?.body
+  if (typeof body !== "string") throw new Error("expected fetch call with JSON body")
+  return JSON.parse(body) as Record<string, unknown>
+}
+
+const baseAnn = {
+  fairId: "f1",
+  fairName: "Spring Fair",
+  fairStartTime: null as number | null,
+  fairEndTime: null as number | null,
+  publishedAt: null as number | null,
+  createdAt: 1000,
+  updatedAt: 1000,
+  createdBy: "admin-1",
+}
+
+describe("FairAdminDashboard — fair announcements (admin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNavigate.mockClear()
+
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      role: "administrator",
+    })
+
+    vi.mocked(useFair).mockReturnValue({
+      setFair: vi.fn(),
+      loading: false,
+      fair: {
+        id: "f1",
+        name: "Spring Fair",
+        description: "Desc",
+        isLive: false,
+        startTime: null,
+        endTime: null,
+        inviteCode: "ABC123",
+      },
+      isLive: false,
+      fairId: "f1",
+    })
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [] }) })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it("shows empty state when there are no announcements", async () => {
+    renderFairAdminDashboard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /fair announcements/i })).toBeInTheDocument()
+    })
+    expect(screen.getByText("No announcements yet.")).toBeInTheDocument()
+  })
+
+  it("lists announcements with draft and published rows", async () => {
+    const announcements = [
+      {
+        id: "a1",
+        ...baseAnn,
+        title: "Parking",
+        description: "Use lot B",
+        published: false,
+      },
+      {
+        id: "a2",
+        ...baseAnn,
+        title: "Lunch",
+        description: "",
+        published: true,
+      },
+    ]
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements }) })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => {
+      expect(screen.getByText("Parking")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Lunch")).toBeInTheDocument()
+    expect(screen.getByText("Use lot B")).toBeInTheDocument()
+    expect(screen.getAllByText("Published").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText("Draft")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^publish$/i })).toBeInTheDocument()
+  })
+
+  it("requires a title before save draft", async () => {
+    const user = userEvent.setup()
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /new announcement/i }))
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+
+    expect(await screen.findByText("Title is required")).toBeInTheDocument()
+  })
+
+  it("creates a draft via POST with published false", async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "POST") {
+        return mockFetchResponse({
+          ok: true,
+          json: async () => ({
+            id: "new-1",
+            ...baseAnn,
+            title: "Hi",
+            description: "",
+            published: false,
+          }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /new announcement/i }))
+    await user.type(screen.getByLabelText(/^title/i), "Hi")
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => requestUrlString(c[0]).includes("/announcements") && c[1]?.method === "POST",
+      )
+      expect(parseFetchCallJsonBody(post)).toMatchObject({
+        title: "Hi",
+        published: false,
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Announcement saved")).toBeInTheDocument()
+    })
+  })
+
+  it("publishes a new announcement via POST with published true", async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "POST") {
+        return mockFetchResponse({
+          ok: true,
+          json: async () => ({
+            id: "new-2",
+            ...baseAnn,
+            title: "Go",
+            description: "Now",
+            published: true,
+          }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /new announcement/i }))
+    await user.type(screen.getByLabelText(/^title/i), "Go")
+    await user.type(screen.getByLabelText(/description/i), "Now")
+    await user.click(screen.getByRole("button", { name: /^publish$/i }))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => requestUrlString(c[0]).includes("/announcements") && c[1]?.method === "POST",
+      )
+      expect(parseFetchCallJsonBody(post)).toEqual({
+        title: "Go",
+        description: "Now",
+        published: true,
+      })
+    })
+  })
+
+  it("updates an announcement via PUT from the edit dialog", async () => {
+    const user = userEvent.setup()
+    const draft = {
+      id: "ann-edit",
+      ...baseAnn,
+      title: "Old",
+      description: "Text",
+      published: false,
+    }
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [draft] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${draft.id}`) && method === "PUT") {
+        return mockFetchResponse({
+          ok: true,
+          json: async () => ({ ...draft, title: "New title" }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByText("Old")).toBeInTheDocument())
+    const table = screen.getByRole("table")
+    await user.click(within(table).getByTitle("Edit"))
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: /edit announcement/i })).toBeInTheDocument())
+    const titleField = screen.getByLabelText(/^title/i)
+    await user.clear(titleField)
+    await user.type(titleField, "New title")
+    await user.click(screen.getByRole("button", { name: /save changes/i }))
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(
+        (c) =>
+          requestUrlString(c[0]).includes(`/announcements/${draft.id}`) && c[1]?.method === "PUT",
+      )
+      expect(parseFetchCallJsonBody(put)).toMatchObject({
+        title: "New title",
+        published: false,
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Announcement updated")).toBeInTheDocument()
+    })
+  })
+
+  it("publishes a draft row using PUT from the table", async () => {
+    const user = userEvent.setup()
+    const draft = {
+      id: "ann-pub",
+      ...baseAnn,
+      title: "Draft only",
+      description: "",
+      published: false,
+    }
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [draft] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${draft.id}`) && method === "PUT") {
+        return mockFetchResponse({
+          ok: true,
+          json: async () => ({ ...draft, published: true }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^publish$/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /^publish$/i }))
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(
+        (c) =>
+          requestUrlString(c[0]).includes(`/announcements/${draft.id}`) && c[1]?.method === "PUT",
+      )
+      expect(parseFetchCallJsonBody(put)).toEqual({ published: true })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Announcement published")).toBeInTheDocument()
+    })
+  })
+
+  it("deletes an announcement when delete is confirmed", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(globalThis, "confirm").mockReturnValue(true)
+
+    const row = {
+      id: "ann-del",
+      ...baseAnn,
+      title: "Remove me",
+      description: "",
+      published: true,
+    }
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [row] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${row.id}`) && method === "DELETE") {
+        return mockFetchResponse({ ok: true, json: async () => ({}) })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByText("Remove me")).toBeInTheDocument())
+    const table = screen.getByRole("table")
+    await user.click(within(table).getByTitle("Delete"))
+
+    await waitFor(() => {
+      const del = fetchMock.mock.calls.find(
+        (c) =>
+          requestUrlString(c[0]).includes(`/announcements/${row.id}`) && c[1]?.method === "DELETE",
+      )
+      expect(del).toBeDefined()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Announcement deleted")).toBeInTheDocument()
+    })
+  })
+
+  it("does not delete when confirm is cancelled", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(globalThis, "confirm").mockReturnValue(false)
+
+    const row = {
+      id: "ann-nodelete",
+      ...baseAnn,
+      title: "Stay",
+      description: "",
+      published: true,
+    }
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [row] }) })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByText("Stay")).toBeInTheDocument())
+    await user.click(within(screen.getByRole("table")).getByTitle("Delete"))
+
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining(`/announcements/${row.id}`),
+      expect.objectContaining({ method: "DELETE" }),
+    )
+  })
+
+  it("shows an error when publish from the table fails", async () => {
+    const user = userEvent.setup()
+    const draft = {
+      id: "ann-bad",
+      ...baseAnn,
+      title: "X",
+      description: "",
+      published: false,
+    }
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [draft] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${draft.id}`) && method === "PUT") {
+        return mockFetchResponse({
+          ok: false,
+          json: async () => ({ error: "Cannot publish" }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^publish$/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /^publish$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Cannot publish")).toBeInTheDocument()
+    })
+  })
+
+  it("shows dialog error when create fails", async () => {
+    const user = userEvent.setup()
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "POST") {
+        return mockFetchResponse({
+          ok: false,
+          json: async () => ({ error: "Bad title" }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /new announcement/i }))
+    await user.type(screen.getByLabelText(/^title/i), "Nope")
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+
+    expect(await screen.findByText("Bad title")).toBeInTheDocument()
+  })
+
+  it("toggles published switch in edit dialog and sends published true on save", async () => {
+    const user = userEvent.setup()
+    const draft = {
+      id: "ann-switch",
+      ...baseAnn,
+      title: "Switch me",
+      description: "",
+      published: false,
+    }
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [draft] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${draft.id}`) && method === "PUT") {
+        return mockFetchResponse({
+          ok: true,
+          json: async () => ({ ...draft, published: true }),
+        })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+    globalThis.fetch = fetchMock
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByText("Switch me")).toBeInTheDocument())
+    await user.click(within(screen.getByRole("table")).getByTitle("Edit"))
+
+    const dlg = await screen.findByRole("dialog", { name: /edit announcement/i })
+    expect(within(dlg).getByText("Draft")).toBeInTheDocument()
+
+    const pubSwitch = within(dlg).getByRole("switch", { name: /^draft$/i })
+    await user.click(pubSwitch)
+
+    expect(within(dlg).getByText("Published")).toBeInTheDocument()
+
+    await user.click(within(dlg).getByRole("button", { name: /save changes/i }))
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(
+        (c) =>
+          requestUrlString(c[0]).includes(`/announcements/${draft.id}`) && c[1]?.method === "PUT",
+      )
+      expect(parseFetchCallJsonBody(put)).toMatchObject({
+        title: "Switch me",
+        published: true,
+      })
+    })
+  })
+
+  it("closes the announcement dialog on Escape when not saving", async () => {
+    const user = userEvent.setup()
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /new announcement/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /new announcement/i }))
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: /new announcement/i })).toBeInTheDocument())
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /new announcement/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows Publishing… on the row button while publish request is in flight", async () => {
+    const user = userEvent.setup()
+    const draft = {
+      id: "ann-slow",
+      ...baseAnn,
+      title: "Slow pub",
+      description: "",
+      published: false,
+    }
+
+    let resolvePut!: (value: Response) => void
+    const putPromise = new Promise<Response>((resolve) => {
+      resolvePut = resolve
+    })
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [draft] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${draft.id}`) && method === "PUT") {
+        return putPromise
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^publish$/i })).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /^publish$/i }))
+
+    expect(await screen.findByText("Publishing…")).toBeInTheDocument()
+
+    void mockFetchResponse({
+      ok: true,
+      json: async () => ({ ...draft, published: true }),
+    }).then((r) => resolvePut(r))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Publishing…")).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows an error when delete fails", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(globalThis, "confirm").mockReturnValue(true)
+
+    const row = {
+      id: "ann-fail-del",
+      ...baseAnn,
+      title: "Err",
+      description: "",
+      published: true,
+    }
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const u = requestUrlString(input)
+      const method = init?.method ?? "GET"
+      if (u.includes("/api/fairs/f1/enrollments") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+      }
+      if (u.includes("/api/fairs/f1/announcements") && method === "GET") {
+        return mockFetchResponse({ ok: true, json: async () => ({ announcements: [row] }) })
+      }
+      if (u.includes(`/api/fairs/f1/announcements/${row.id}`) && method === "DELETE") {
+        return mockFetchResponse({ ok: false, json: async () => ({}) })
+      }
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    })
+
+    renderFairAdminDashboard()
+
+    await waitFor(() => expect(screen.getByText("Err")).toBeInTheDocument())
+    await user.click(within(screen.getByRole("table")).getByTitle("Delete"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to delete")).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/FairAdminDashboard.hub.test.tsx
+++ b/frontend/src/pages/__tests__/FairAdminDashboard.hub.test.tsx
@@ -78,6 +78,72 @@ function clickChipDeleteInDialog(dialog: HTMLElement, chipAccessibleName: RegExp
   fireEvent.click(icon)
 }
 
+function requestUrlString(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+/** Minimal Response shape used by app code (ok + json); satisfies `typeof fetch` for tests. */
+function mockFetchResponse(data: {
+  ok: boolean
+  status?: number
+  json: () => Promise<unknown>
+}): Promise<Response> {
+  return Promise.resolve(data as unknown as Response)
+}
+
+/** FairAdminDashboard fires enrollments + announcements GETs in parallel on mount; mockResolvedValueOnce order is nondeterministic. */
+function stubFairAdminDashboardFetch(opts: {
+  putResponse?: { ok: boolean; status: number; json: () => Promise<unknown> }
+  getFairAfterPut?: Record<string, unknown>
+}) {
+  const fairId = "f1"
+  const impl: typeof fetch = (input, init) => {
+    const u = requestUrlString(input)
+    const method = init?.method ?? "GET"
+
+    if (u.includes(`/api/fairs/${fairId}/enrollments`) && method === "GET") {
+      return mockFetchResponse({ ok: true, json: async () => ({ enrollments: [] }) })
+    }
+    if (u.includes(`/api/fairs/${fairId}/announcements`) && method === "GET") {
+      return mockFetchResponse({ ok: true, json: async () => ({ announcements: [] }) })
+    }
+
+    const isFairPut =
+      method === "PUT" &&
+      u.includes(`/api/fairs/${fairId}`) &&
+      !u.includes("/enrollments") &&
+      !u.includes("/announcements") &&
+      !u.includes("/toggle") &&
+      !u.includes("/refresh") &&
+      !u.includes("/enroll")
+
+    if (isFairPut && opts.putResponse) {
+      return mockFetchResponse(opts.putResponse)
+    }
+    if (isFairPut && !opts.putResponse) {
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    }
+
+    const isFairGet =
+      method === "GET" &&
+      u.includes(`/api/fairs/${fairId}`) &&
+      !u.includes("/enrollments") &&
+      !u.includes("/announcements")
+
+    if (isFairGet && opts.getFairAfterPut) {
+      return mockFetchResponse({ ok: true, json: async () => opts.getFairAfterPut })
+    }
+    if (isFairGet) {
+      return mockFetchResponse({ ok: true, json: async () => ({}) })
+    }
+
+    return mockFetchResponse({ ok: true, json: async () => ({}) })
+  }
+  return vi.fn(impl)
+}
+
 describe("FairAdminDashboard — venue hub / edit save", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -264,18 +330,15 @@ describe("FairAdminDashboard — venue hub / edit save", () => {
 
   it("shows API error status when PUT fails and response body is not JSON", async () => {
     const user = userEvent.setup()
-    globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ enrollments: [] }),
-      })
-      .mockResolvedValueOnce({
+    globalThis.fetch = stubFairAdminDashboardFetch({
+      putResponse: {
         ok: false,
         status: 502,
         json: async () => {
           throw new SyntaxError("bad json")
         },
-      })
+      },
+    })
 
     renderFairAdminDashboard()
 
@@ -296,19 +359,7 @@ describe("FairAdminDashboard — venue hub / edit save", () => {
       inviteCode: "ABC123",
       venueCity: "Raleigh",
     }
-    globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ enrollments: [] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({}),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => refreshedFair,
-      })
+    globalThis.fetch = stubFairAdminDashboardFetch({ getFairAfterPut: refreshedFair })
 
     renderFairAdminDashboard()
 

--- a/frontend/src/pages/__tests__/FairAdminDashboard.test.tsx
+++ b/frontend/src/pages/__tests__/FairAdminDashboard.test.tsx
@@ -56,11 +56,25 @@ const renderFairAdminDashboard = () =>
     </BrowserRouter>
   )
 
+/** Initial fair-admin load calls GET enrollments then GET announcements (fair id f1 in tests). */
+function mockFetchAnnouncementsOk() {
+  return { ok: true, json: async () => ({ announcements: [] }) }
+}
+
 describe("FairAdminDashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockNavigate.mockClear()
-    globalThis.fetch = vi.fn()
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
+    })
 
     // Default: administrator
     vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
@@ -84,12 +98,6 @@ describe("FairAdminDashboard", () => {
       },
       isLive: false,
       fairId: "f1",
-    })
-
-    // Default fetch: enrollments endpoint returns empty list
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ enrollments: [] }),
     })
   })
 
@@ -266,9 +274,15 @@ describe("FairAdminDashboard — invite code", () => {
       fairId: "f1",
     })
 
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ enrollments: [] }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
     })
 
     // Mock clipboard writeText as a spy
@@ -291,12 +305,13 @@ describe("FairAdminDashboard — invite code", () => {
   it("calls refresh invite code endpoint and clears Copied state", async () => {
     const user = userEvent.setup()
 
-    // First call = enrollments, second = refresh-invite-code
+    // enrollments, announcements, refresh-invite-code
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ inviteCode: "XYZ789" }),
@@ -325,6 +340,7 @@ describe("FairAdminDashboard — invite code", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         status: 500,
@@ -353,6 +369,7 @@ describe("FairAdminDashboard — invite code", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         status: 503,
@@ -401,9 +418,15 @@ describe("FairAdminDashboard — toggle live", () => {
       fairId: "f1",
     })
 
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ enrollments: [] }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
     })
   })
 
@@ -420,6 +443,7 @@ describe("FairAdminDashboard — toggle live", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({}),
@@ -446,6 +470,7 @@ describe("FairAdminDashboard — toggle live", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         json: async () => ({}),
@@ -491,9 +516,15 @@ describe("FairAdminDashboard — add company dialog", () => {
       fairId: "f1",
     })
 
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ enrollments: [] }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
     })
   })
 
@@ -505,6 +536,7 @@ describe("FairAdminDashboard — add company dialog", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         json: async () => ({ error: "Company not found" }),
@@ -533,6 +565,7 @@ describe("FairAdminDashboard — add company dialog", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ success: true }),
@@ -609,13 +642,19 @@ describe("FairAdminDashboard — enrolled companies table", () => {
   })
 
   it("renders enrolled companies in the table", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        enrollments: [
-          { id: "c1", companyName: "Acme Corp", enrollmentMethod: "invite", enrolledAt: { seconds: 1700000000 } },
-        ],
-      }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          enrollments: [
+            { id: "c1", companyName: "Acme Corp", enrollmentMethod: "invite", enrolledAt: { seconds: 1700000000 } },
+          ],
+        }),
+      })
     })
 
     renderFairAdminDashboard()
@@ -627,13 +666,19 @@ describe("FairAdminDashboard — enrolled companies table", () => {
   })
 
   it("shows dash for enrollment date when enrolledAt is missing", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        enrollments: [
-          { id: "c1", companyName: "NoDate Corp", enrollmentMethod: "admin", enrolledAt: null },
-        ],
-      }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          enrollments: [
+            { id: "c1", companyName: "NoDate Corp", enrollmentMethod: "admin", enrolledAt: null },
+          ],
+        }),
+      })
     })
 
     renderFairAdminDashboard()
@@ -657,6 +702,7 @@ describe("FairAdminDashboard — enrolled companies table", () => {
           ],
         }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({}),
@@ -684,13 +730,19 @@ describe("FairAdminDashboard — enrolled companies table", () => {
   it("does not remove company when confirm is cancelled", async () => {
     globalThis.confirm = vi.fn().mockReturnValue(false)
 
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        enrollments: [
-          { id: "c1", companyName: "Acme Corp", enrollmentMethod: "admin", enrolledAt: null },
-        ],
-      }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          enrollments: [
+            { id: "c1", companyName: "Acme Corp", enrollmentMethod: "admin", enrolledAt: null },
+          ],
+        }),
+      })
     })
 
     const user = userEvent.setup()
@@ -717,6 +769,7 @@ describe("FairAdminDashboard — enrolled companies table", () => {
           ],
         }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         json: async () => ({}),
@@ -762,9 +815,15 @@ describe("FairAdminDashboard — edit fair dialog", () => {
       fairId: "f1",
     })
 
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ enrollments: [] }),
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      const u = String(url)
+      if (u.includes("/f1/announcements")) {
+        return Promise.resolve(mockFetchAnnouncementsOk())
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
     })
   })
 
@@ -793,6 +852,7 @@ describe("FairAdminDashboard — edit fair dialog", () => {
         ok: true,
         json: async () => ({ enrollments: [] }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         json: async () => ({ error: "Name is required" }),
@@ -843,6 +903,7 @@ describe("FairAdminDashboard — edit fair dialog", () => {
           ],
         }),
       })
+      .mockResolvedValueOnce(mockFetchAnnouncementsOk())
       .mockResolvedValueOnce({
         ok: false,
         json: async () => ({}),

--- a/frontend/src/pages/__tests__/FairAnnouncementsPage.test.tsx
+++ b/frontend/src/pages/__tests__/FairAnnouncementsPage.test.tsx
@@ -1,0 +1,186 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom" />
+import type { ReactNode } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { BrowserRouter } from "react-router-dom"
+import FairAnnouncementsPage from "../FairAnnouncementsPage"
+import * as authUtils from "../../utils/auth"
+import * as firebase from "../../firebase"
+
+vi.mock("../../utils/auth", () => ({
+  authUtils: {
+    getCurrentUser: vi.fn(),
+  },
+}))
+
+vi.mock("../../firebase", () => ({
+  waitForFirebaseUser: vi.fn(),
+}))
+
+vi.mock("../../components/BaseLayout", () => ({
+  default: ({ children, pageTitle }: { children?: ReactNode; pageTitle?: string }) => (
+    <div data-testid="base-layout">
+      {pageTitle ? <span data-testid="page-title">{pageTitle}</span> : null}
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock("../../config", () => ({
+  API_URL: "http://localhost:5000",
+}))
+
+const renderPage = () =>
+  render(
+    <BrowserRouter>
+      <FairAnnouncementsPage />
+    </BrowserRouter>,
+  )
+
+describe("FairAnnouncementsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.fetch = vi.fn()
+  })
+
+  it("renders nothing when user is null", () => {
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue(null)
+    const { container } = renderPage()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("shows info alert for roles that cannot use the page", () => {
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "u1",
+      email: "s@example.com",
+      role: "student",
+    })
+    renderPage()
+    expect(screen.getByText(/company owners and representatives/i)).toBeInTheDocument()
+  })
+
+  it("shows loading then empty state when announcements fetch succeeds with no rows", async () => {
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "u1",
+      email: "o@example.com",
+      role: "companyOwner",
+      companyId: "c1",
+    })
+    vi.mocked(firebase.waitForFirebaseUser).mockResolvedValue({
+      getIdToken: vi.fn().mockResolvedValue("tok"),
+    } as any)
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ announcements: [] }),
+    } as Response)
+
+    renderPage()
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText(/No published announcements yet for your enrolled fairs/i)).toBeInTheDocument()
+    })
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/api/fairs/my-announcements",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer tok" },
+      }),
+    )
+  })
+
+  it("shows error when session cannot be verified", async () => {
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "u1",
+      email: "o@example.com",
+      role: "representative",
+      companyId: "c1",
+    })
+    vi.mocked(firebase.waitForFirebaseUser).mockResolvedValue(null)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not verify your session/i)).toBeInTheDocument()
+    })
+  })
+
+  it("shows error when API returns non-OK", async () => {
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "u1",
+      email: "o@example.com",
+      role: "companyOwner",
+      companyId: "c1",
+    })
+    vi.mocked(firebase.waitForFirebaseUser).mockResolvedValue({
+      getIdToken: vi.fn().mockResolvedValue("tok"),
+    } as any)
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not load announcements.")).toBeInTheDocument()
+    })
+  })
+
+  it("splits rows into upcoming and past sections", async () => {
+    const now = Date.now()
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "u1",
+      email: "o@example.com",
+      role: "companyOwner",
+      companyId: "c1",
+    })
+    vi.mocked(firebase.waitForFirebaseUser).mockResolvedValue({
+      getIdToken: vi.fn().mockResolvedValue("tok"),
+    } as any)
+
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        announcements: [
+          {
+            id: "a1",
+            fairId: "f1",
+            fairName: "Spring",
+            title: "T1",
+            description: "D1",
+            publishedAt: now,
+            createdAt: now,
+            fairStartTime: now - 86400000,
+            fairEndTime: now + 86400000,
+          },
+          {
+            id: "a2",
+            fairId: "f2",
+            fairName: "Old",
+            title: "T2",
+            description: "",
+            publishedAt: now,
+            createdAt: now,
+            fairStartTime: now - 86400000 * 10,
+            fairEndTime: now - 86400000,
+          },
+        ],
+      }),
+    } as Response)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Upcoming and current fairs")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Spring")).toBeInTheDocument()
+    expect(screen.getByText("Active / upcoming")).toBeInTheDocument()
+
+    expect(screen.getByText("Past fairs")).toBeInTheDocument()
+    expect(screen.getByText("Old")).toBeInTheDocument()
+    expect(screen.getByText("Past fair")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/FairLanding.test.tsx
+++ b/frontend/src/pages/__tests__/FairLanding.test.tsx
@@ -7,7 +7,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { BrowserRouter } from "react-router-dom"
 import FairLanding from "../FairLanding"
 import * as authUtils from "../../utils/auth"
-import { auth } from "../../firebase"
 import { useFair } from "../../contexts/FairContext"
 
 const mockNavigate = vi.fn()
@@ -44,12 +43,26 @@ vi.mock("../../config", () => ({
   API_URL: "http://localhost:5000",
 }))
 
+const fairLandingFirebaseMocks = vi.hoisted(() => {
+  const getIdToken = vi.fn().mockResolvedValue("mock-token")
+  const user = { getIdToken: () => getIdToken() as Promise<string> }
+  return {
+    getIdToken,
+    waitForFirebaseUser: vi.fn(() => Promise.resolve(user)),
+  }
+})
+
 vi.mock("../../firebase", () => ({
+  waitForFirebaseUser: fairLandingFirebaseMocks.waitForFirebaseUser,
   auth: {
     currentUser: {
-      getIdToken: vi.fn().mockResolvedValue("mock-token"),
+      getIdToken: fairLandingFirebaseMocks.getIdToken,
     },
   },
+}))
+
+vi.mock("../../utils/ownedCompanies", () => ({
+  fetchOwnedCompaniesForUser: vi.fn().mockResolvedValue([]),
 }))
 
 const renderFairLanding = () =>
@@ -64,6 +77,7 @@ describe("FairLanding", () => {
     vi.clearAllMocks()
     mockNavigate.mockClear()
     globalThis.fetch = vi.fn()
+    fairLandingFirebaseMocks.getIdToken.mockResolvedValue("mock-token")
 
     // Default: non-company student user
     vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
@@ -225,7 +239,7 @@ describe("FairLanding", () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1" }] }),
+      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1", companyId: "company-1" }] }),
     })
 
     renderFairLanding()
@@ -622,7 +636,7 @@ describe("FairLanding", () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1" }] }),
+      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1", companyId: "company-1" }] }),
     })
 
     renderFairLanding()
@@ -656,7 +670,7 @@ describe("FairLanding", () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1" }] }),
+      json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1", companyId: "company-1" }] }),
     })
 
     renderFairLanding()
@@ -697,7 +711,7 @@ describe("FairLanding", () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1" }] }),
+        json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1", companyId: "company-1" }] }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -742,7 +756,7 @@ describe("FairLanding", () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1" }] }),
+        json: async () => ({ enrollments: [{ fairId: "f1", boothId: "booth-1", companyId: "company-1" }] }),
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -1128,7 +1142,7 @@ describe("FairLanding", () => {
     })
     const fetchMock = vi.fn()
     globalThis.fetch = fetchMock
-    vi.mocked(auth.currentUser!.getIdToken).mockResolvedValueOnce("" as unknown as string)
+    fairLandingFirebaseMocks.getIdToken.mockResolvedValueOnce("" as unknown as string)
     renderFairLanding()
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /join this fair/i })).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/FairList.test.tsx
+++ b/frontend/src/pages/__tests__/FairList.test.tsx
@@ -724,6 +724,74 @@ describe("FairList — enrollment edge cases", () => {
     if (origCurrentUser) Object.defineProperty(firebaseMock.auth, "currentUser", origCurrentUser)
     if (origOnAuthStateChanged) Object.defineProperty(firebaseMock.auth, "onAuthStateChanged", origOnAuthStateChanged)
   })
+
+  it("resolves local waitForFirebaseUser when auth restores user via onAuthStateChanged", async () => {
+    const firebaseMock = await import("../../firebase")
+    const origCurrentUser = Object.getOwnPropertyDescriptor(firebaseMock.auth, "currentUser")
+    const origOnAuthStateChanged = Object.getOwnPropertyDescriptor(firebaseMock.auth, "onAuthStateChanged")
+    const mockUnsub = vi.fn()
+
+    Object.defineProperty(firebaseMock.auth, "currentUser", {
+      get: () => null,
+      configurable: true,
+    })
+    Object.defineProperty(firebaseMock.auth, "onAuthStateChanged", {
+      value: vi.fn((cb: (u: unknown) => void) => {
+        queueMicrotask(() => {
+          cb({ uid: "restored", getIdToken: async () => "tok" })
+        })
+        return mockUnsub
+      }),
+      configurable: true,
+    })
+
+    vi.mocked(authUtils.authUtils.getCurrentUser).mockReturnValue({
+      uid: "owner-1",
+      email: "owner@company.com",
+      role: "companyOwner",
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          fairs: [
+            {
+              id: "f1",
+              name: "Async Session Fair",
+              description: null,
+              isLive: false,
+              startTime: null,
+              endTime: null,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ enrollments: [] }),
+      })
+
+    try {
+      renderFairList()
+
+      await waitFor(() => expect(screen.getByText("Async Session Fair")).toBeInTheDocument())
+
+      await waitFor(() => expect(mockUnsub).toHaveBeenCalled())
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          expect.stringContaining("/api/fairs/my-enrollments"),
+          expect.objectContaining({
+            headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+          }),
+        )
+      })
+    } finally {
+      if (origCurrentUser) Object.defineProperty(firebaseMock.auth, "currentUser", origCurrentUser)
+      if (origOnAuthStateChanged) Object.defineProperty(firebaseMock.auth, "onAuthStateChanged", origOnAuthStateChanged)
+    }
+  })
 })
 
 describe("FairList — join fair flow", () => {

--- a/frontend/src/pages/__tests__/FairList.test.tsx
+++ b/frontend/src/pages/__tests__/FairList.test.tsx
@@ -78,6 +78,10 @@ vi.mock("../../firebase", () => ({
   },
 }))
 
+vi.mock("../../utils/ownedCompanies", () => ({
+  fetchOwnedCompaniesForUser: vi.fn().mockResolvedValue([]),
+}))
+
 const renderFairList = () =>
   render(
     <BrowserRouter>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,9 @@
 import "@testing-library/jest-dom/vitest"
+import { configure } from "@testing-library/react"
 import { vi } from "vitest"
+
+// Default 1000ms is too tight when many workers run heavy jsdom + userEvent suites.
+configure({ asyncUtilTimeout: 10_000 })
 
 // Mock import.meta.env
 vi.stubEnv("VITE_FIREBASE_API_KEY", "test-api-key")

--- a/frontend/src/utils/__tests__/ownedCompanies.test.ts
+++ b/frontend/src/utils/__tests__/ownedCompanies.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getDocs } from "firebase/firestore"
+import { fetchOwnedCompaniesForUser } from "../ownedCompanies"
+
+describe("fetchOwnedCompaniesForUser", () => {
+  beforeEach(() => {
+    vi.mocked(getDocs).mockReset()
+  })
+
+  it("maps docs, uses document id when companyName is missing, blank, or non-string; sorts by name", async () => {
+    vi.mocked(getDocs).mockResolvedValue({
+      forEach: (fn: (doc: { id: string; data: () => Record<string, unknown> }) => void) => {
+        fn({ id: "z-id", data: () => ({ companyName: "Zebra Co" }) })
+        fn({ id: "n-id", data: () => ({ companyName: "   " }) })
+        fn({ id: "a-id", data: () => ({ companyName: "Alpha" }) })
+        fn({ id: "plain-id", data: () => ({ companyName: undefined }) })
+        fn({ id: "num-id", data: () => ({ companyName: 99 }) })
+      },
+    } as any)
+
+    const result = await fetchOwnedCompaniesForUser("owner-uid")
+
+    expect(result).toEqual([
+      { id: "a-id", companyName: "Alpha" },
+      { id: "n-id", companyName: "n-id" },
+      { id: "num-id", companyName: "num-id" },
+      { id: "plain-id", companyName: "plain-id" },
+      { id: "z-id", companyName: "Zebra Co" },
+    ])
+  })
+})

--- a/frontend/src/utils/ownedCompanies.ts
+++ b/frontend/src/utils/ownedCompanies.ts
@@ -1,0 +1,19 @@
+import { collection, getDocs, query, where } from "firebase/firestore"
+import { db } from "../firebase"
+
+export type OwnedCompanySummary = { id: string; companyName: string }
+
+/** Companies in Firestore where `ownerId` is the given user (company owners only). */
+export async function fetchOwnedCompaniesForUser(ownerUid: string): Promise<OwnedCompanySummary[]> {
+  const q = query(collection(db, "companies"), where("ownerId", "==", ownerUid))
+  const snap = await getDocs(q)
+  const list: OwnedCompanySummary[] = []
+  snap.forEach((docSnap) => {
+    const d = docSnap.data() as { companyName?: string }
+    list.push({
+      id: docSnap.id,
+      companyName: typeof d.companyName === "string" && d.companyName.trim() ? d.companyName : docSnap.id,
+    })
+  })
+  return list.sort((a, b) => a.companyName.localeCompare(b.companyName))
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,11 @@
 /// <reference types="vitest/config" />
+import { cpus } from 'node:os'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+// Cap parallel test workers: many jsdom + userEvent suites in parallel can exceed timeouts on
+// busy CPUs (common on Windows and in CI). Vitest defaults to cpu count, which is often too high.
+const maxTestWorkers = Math.min(4, cpus().length)
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -24,7 +29,9 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: false,
-    testTimeout: 15000,
+    maxWorkers: maxTestWorkers,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
# PR: Fair announcements for exhibitors (admin, banner, history page)

## What does this PR do?
Adds organizer-managed **fair announcements** (title, optional description, publish/draft) stored per fair, surfaces **published** announcements to **company owners and representatives** for fairs their company is enrolled in, and provides a **dashboard banner** (dismissible per announcement) plus a **Fair announcements** history page. It also extends announcement payloads with **fair start/end times** for “past vs current” grouping and fixes **banner reload** after navigation by waiting for Firebase auth before fetching.

## Changes
- **Backend (`backend/routes/fairs.js`)**: Firestore subcollection `fairs/{fairId}/announcements/{announcementId}` with admin CRUD; `GET /api/fairs/my-announcements` for owners/reps (published only, enrolled fairs, sorted by `createdAt` desc); serialized fields include `fairStartTime` / `fairEndTime` (ms); `GET /api/fairs/my-enrollments` returns `companyId` per enrollment row (supports multi-company owners).
- **Fair admin UI (`frontend/src/pages/FairAdminDashboard.tsx`)**: Table + create/edit dialog; **Save draft** / **Publish**; publish action for draft rows.
- **Banner (`frontend/src/components/FairAnnouncementsBanner.tsx`)**: Loads `my-announcements`, dismiss via `localStorage` (`fairAnnouncementDismissed:{uid}:{announcementId}`), optional fair link; uses `waitForFirebaseUser()` before token fetch so announcements reappear after returning to the dashboard.
- **Dashboard (`frontend/src/pages/Dashboard.tsx`)**: Renders the banner inside the main `Container` (removed from `BaseLayout`) for consistent spacing with the welcome card.
- **History page (`frontend/src/pages/FairAnnouncementsPage.tsx`)**: Route `/dashboard/fair-announcements`; tables grouped into upcoming/current vs past fairs; links to fair detail.
- **Navigation (`frontend/src/components/BaseLayout.tsx`, `frontend/src/App.tsx`)**: Drawer item **Fair announcements** for company owners and representatives; new route wired in `App.tsx`.
- **Tests**: Backend coverage in `backend/__tests__/fairs2.test.js`; frontend tests updated (e.g. `FairAdminDashboard.test.tsx`, `BaseLayout.test.tsx`, `FairLanding.test.tsx`, `FairList.test.tsx`, `firebase.test.ts` mock for `onAuthStateChanged`).

## How to Test
1. As **fair admin**, open `/fair/:fairId/admin`, create an announcement, **Save draft**, then **Publish**; confirm it appears in the list and republish flow works.
2. As **company owner or rep** with an enrolled company, open **Dashboard**: confirm the **banner** shows published announcements with fair name link; dismiss with **X** and confirm it stays dismissed for that announcement until localStorage is cleared.
3. Navigate away (e.g. Browse Fairs) and back to **Dashboard**: confirm announcements **load again** without dismiss (Firebase timing fix).
4. Open **Fair announcements** from the nav (`/dashboard/fair-announcements`): confirm full list, past vs upcoming sections, and fair links.
5. Run **backend**: `npx jest __tests__/fairs2.test.js` (and related suites); **frontend**: `npx tsc --noEmit` and `npx vitest run` for touched tests.

## Jira Issues
Closes SCRUM 28

## Notes
- Banner is **dashboard-only**; other routes do not show it.
- Dismissal is **per user, per announcement** in `localStorage`, not server-side.
- `my-announcements` only includes **published** announcements for **enrolled** fairs; multi-company owners rely on aggregated enrollments / company selection elsewhere in the app.