### PR TITLE
Make the Chat Page look fine again

### DIFF
--- a/frontend/src/components/BaseLayout.tsx
+++ b/frontend/src/components/BaseLayout.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material"
 import MenuIcon from "@mui/icons-material/Menu"
 import CloseIcon from "@mui/icons-material/Close"
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 import ChatIcon from "@mui/icons-material/Chat"
 import DashboardIcon from "@mui/icons-material/Dashboard"
 import EventIcon from "@mui/icons-material/Event"
@@ -108,6 +109,10 @@ export interface BaseLayoutProps {
   pageTitle?: string
   /** When false, hides the floating Fairy Jobmother help widget. Default true. */
   showJobmotherAssistant?: boolean
+  /** Shown before the page title (after the divider), e.g. navigate back from chat. */
+  onHeaderBack?: () => void
+  /** Extra controls in the header action row (before the global Chat button). */
+  headerActions?: React.ReactNode
 }
 
 export default function BaseLayout({
@@ -115,6 +120,8 @@ export default function BaseLayout({
   showChat = true,
   pageTitle,
   showJobmotherAssistant = true,
+  onHeaderBack,
+  headerActions,
 }: Readonly<BaseLayoutProps>) {
   const navigate = useNavigate()
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -197,6 +204,22 @@ export default function BaseLayout({
               {pageTitle && (
                 <>
                   <Box sx={{ width: "1px", height: 32, bgcolor: "rgba(255,255,255,0.3)", mx: 0.5 }} />
+                  {onHeaderBack && (
+                    <Tooltip title="Back to Dashboard">
+                      <IconButton
+                        onClick={onHeaderBack}
+                        aria-label="Back to Dashboard"
+                        sx={{
+                          color: "white",
+                          background: "rgba(255,255,255,0.15)",
+                          border: "1px solid rgba(255,255,255,0.3)",
+                          "&:hover": { background: "rgba(255,255,255,0.25)" },
+                        }}
+                      >
+                        <ArrowBackIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
                   <Typography
                     variant="h6"
                     sx={{ fontWeight: 600, color: "white", letterSpacing: "-0.3px" }}
@@ -209,6 +232,7 @@ export default function BaseLayout({
 
             {/* Right: actions */}
             <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+              {headerActions}
               {showChat && (
                 <Tooltip title="Open Chat">
                   <Button

--- a/frontend/src/components/__tests__/BaseLayout.test.tsx
+++ b/frontend/src/components/__tests__/BaseLayout.test.tsx
@@ -78,6 +78,23 @@ describe("BaseLayout", () => {
       expect(screen.getByText("My Page")).toBeInTheDocument()
     })
 
+    it("renders header back button and calls onHeaderBack when provided with pageTitle", async () => {
+      const user = userEvent.setup()
+      const onBack = vi.fn()
+      renderLayout({ children: <div />, pageTitle: "Chat", onHeaderBack: onBack })
+      await user.click(screen.getByRole("button", { name: "Back to Dashboard" }))
+      expect(onBack).toHaveBeenCalledTimes(1)
+    })
+
+    it("renders headerActions before the Chat button", () => {
+      renderLayout({
+        children: <div />,
+        pageTitle: "Messages",
+        headerActions: <span data-testid="extra-action">Extra</span>,
+      })
+      expect(screen.getByTestId("extra-action")).toBeInTheDocument()
+    })
+
     it("does not render a page title when prop is omitted", () => {
       renderLayout({ children: <div /> })
       // Only branding text should be present, no extra titles

--- a/frontend/src/components/__tests__/BaseLayout.test.tsx
+++ b/frontend/src/components/__tests__/BaseLayout.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vitest/globals" />
 /// <reference types="@testing-library/jest-dom" />
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { BrowserRouter } from "react-router-dom"
@@ -160,6 +160,37 @@ describe("BaseLayout", () => {
   it("renders the ProfileMenu", () => {
     renderLayout()
     expect(screen.getByTestId("profile-menu")).toBeInTheDocument()
+  })
+
+  // ─── Header height (ResizeObserver) ───────────────────────────────────────
+
+  describe("header ResizeObserver", () => {
+    let observeSpy: ReturnType<typeof vi.fn>
+    let disconnectSpy: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      observeSpy = vi.fn()
+      disconnectSpy = vi.fn()
+      function MockResizeObserver(
+        this: { observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> },
+        _cb: ResizeObserverCallback
+      ) {
+        this.observe = observeSpy
+        this.disconnect = disconnectSpy
+      }
+      vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it("attaches ResizeObserver to the header and disconnects on unmount", () => {
+      const { unmount } = renderLayout()
+      expect(observeSpy).toHaveBeenCalled()
+      unmount()
+      expect(disconnectSpy).toHaveBeenCalled()
+    })
   })
 
   // ─── Navigation drawer ─────────────────────────────────────────────────────

--- a/frontend/src/pages/ChatPage.css
+++ b/frontend/src/pages/ChatPage.css
@@ -1,7 +1,9 @@
 .chat-page {
   display: flex;
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
+  flex-direction: column;
 }
 
 .chat-main-wrapper {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -69,6 +69,8 @@ export default function ChatPage() {
       return;
     }
 
+    let removeNotificationListeners: (() => void) | undefined;
+
     const init = async () => {
       try {
         // If Stream is connected as someone else → disconnect
@@ -121,7 +123,7 @@ export default function ChatPage() {
         client.on("notification.message_new", updateUnread);
         client.on("notification.mark_read", updateUnread);
 
-        return () => {
+        removeNotificationListeners = () => {
           client.off("notification.message_new", updateUnread);
           client.off("notification.mark_read", updateUnread);
         };
@@ -131,6 +133,9 @@ export default function ChatPage() {
     };
 
     void init();
+    return () => {
+      removeNotificationListeners?.();
+    };
   }, [user, client]);
 
   /*

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type React from "react";
-import { Box, CircularProgress, Typography } from "@mui/material";
+import { Box, CircularProgress, IconButton, Tooltip, Typography } from "@mui/material";
+import AddCommentIcon from "@mui/icons-material/AddComment";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_URL } from "../config";
 import type { Channel as StreamChannel } from "stream-chat";
@@ -14,14 +15,20 @@ import {
 
 import "stream-chat-react/dist/css/v2/index.css";
 
-import ChatHeader from "../components/chat/ChatHeader";
 import ChatSidebar from "../components/chat/ChatSidebar";
 import NewChatDialog from "../components/chat/NewChatDialog";
+import BaseLayout from "../components/BaseLayout";
 
 import { authUtils } from "../utils/auth";
 import { auth } from "../firebase";
 import { streamClient } from "../utils/streamClient";
 import "./ChatPage.css";
+
+const CHAT_SHELL_SX = {
+  minHeight: "calc(100vh - var(--base-layout-header-height, 88px))",
+  display: "flex",
+  flexDirection: "column" as const,
+};
 
 export default function ChatPage() {
   const navigate = useNavigate();
@@ -223,104 +230,130 @@ export default function ChatPage() {
   // If streamClient is missing entirely
   if (!client) {
     return (
-      <Box className="chat-center-container">
-        <Box className="chat-center-content">
-          <Typography variant="h6" className="chat-not-available">
-            Chat Not Available
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Stream Chat API key is not configured. Please set VITE_STREAM_API_KEY in your environment variables.
-          </Typography>
+      <BaseLayout pageTitle="Chat" showChat={false} onHeaderBack={() => navigate("/dashboard")}>
+        <Box sx={CHAT_SHELL_SX}>
+          <Box className="chat-center-container">
+            <Box className="chat-center-content">
+              <Typography variant="h6" className="chat-not-available">
+                Chat Not Available
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Stream Chat API key is not configured. Please set VITE_STREAM_API_KEY in your environment variables.
+              </Typography>
+            </Box>
+          </Box>
         </Box>
-      </Box>
+      </BaseLayout>
     );
   }
 
   // SAFE LOADING RETURN (NO HOOKS HERE)
   if (!clientReady || !client.userID) {
     return (
-      <Box className="chat-loading-container">
-        <CircularProgress />
-      </Box>
+      <BaseLayout pageTitle="Chat" showChat={false} onHeaderBack={() => navigate("/dashboard")}>
+        <Box sx={CHAT_SHELL_SX}>
+          <Box className="chat-loading-container">
+            <CircularProgress />
+          </Box>
+        </Box>
+      </BaseLayout>
     );
   }
 
   // Main chat UI
   const titleSuffix = unreadCount ? ` (${unreadCount})` : "";
   return (
-    <Box className="chat-page">
-      <ChatHeader
-        title={`Messages${titleSuffix}`}
-        onNewChat={() => setDialogOpen(true)}
-        onBack={() => navigate("/dashboard")}
-      />
+    <BaseLayout
+      pageTitle={`Messages${titleSuffix}`}
+      showChat={false}
+      onHeaderBack={() => navigate("/dashboard")}
+      headerActions={
+        <Tooltip title="Start New Chat">
+          <IconButton
+            onClick={() => setDialogOpen(true)}
+            aria-label="Start New Chat"
+            sx={{
+              color: "white",
+              background: "rgba(255,255,255,0.15)",
+              border: "1px solid rgba(255,255,255,0.3)",
+              "&:hover": { background: "rgba(255,255,255,0.25)" },
+            }}
+          >
+            <AddCommentIcon />
+          </IconButton>
+        </Tooltip>
+      }
+    >
+      <Box sx={CHAT_SHELL_SX}>
+        <Box className="chat-page">
+          <Box className="chat-main-wrapper">
+            <Chat client={client} theme="messaging light">
+              <ChatSidebar
+                client={client}
+                onSelectChannel={handleSelectChannel}
+                activeChannel={activeChannel}
+              />
 
-      <Box className="chat-main-wrapper">
-        <Chat client={client} theme="messaging light">
-          <ChatSidebar
-            client={client}
-            onSelectChannel={handleSelectChannel}
-            activeChannel={activeChannel}
-          />
+              <Box className="chat-messages-wrapper">
+                {activeChannel ? (
+                  <Channel channel={activeChannel}>
+                    <Window>
+                      <Box className="chat-messages-container">
+                        {/* MESSAGE LIST */}
+                        <Box className="chat-message-list">
+                          <MessageList />
+                        </Box>
 
-          <Box className="chat-messages-wrapper">
-            {activeChannel ? (
-              <Channel channel={activeChannel}>
-                <Window>
-                  <Box className="chat-messages-container">
-                    {/* MESSAGE LIST */}
-                    <Box className="chat-message-list">
-                      <MessageList />
-                    </Box>
+                        {/* INPUT BAR */}
+                        <Box className="chat-input-bar">
+                          {/* FILE UPLOAD */}
+                          <label className="chat-file-upload-label">
+                            {"📎"}
+                            <input
+                              type="file"
+                              multiple
+                              className="chat-file-upload-input"
+                              onChange={(e) => {
+                                if (e.target.files) {
+                                  void sendFiles(e.target.files);
+                                  e.target.value = "";
+                                }
+                              }}
+                            />
+                          </label>
 
-                    {/* INPUT BAR */}
-                    <Box className="chat-input-bar">
-                      {/* FILE UPLOAD */}
-                      <label className="chat-file-upload-label">
-                        {"📎"}
-                        <input
-                          type="file"
-                          multiple
-                          className="chat-file-upload-input"
-                          onChange={(e) => {
-                            if (e.target.files) {
-                              void sendFiles(e.target.files);
-                              e.target.value = "";
-                            }
-                          }}
-                        />
-                      </label>
-
-                      {/* TEXTAREA */}
-                      <textarea
-                        placeholder="Begin typing to send a message..."
-                        value={draftMessage}
-                        onChange={(e) => setDraftMessage(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        onInput={handleInput}
-                        className="chat-textarea"
-                      />
-                    </Box>
+                          {/* TEXTAREA */}
+                          <textarea
+                            placeholder="Begin typing to send a message..."
+                            value={draftMessage}
+                            onChange={(e) => setDraftMessage(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            onInput={handleInput}
+                            className="chat-textarea"
+                          />
+                        </Box>
+                      </Box>
+                    </Window>
+                  </Channel>
+                ) : (
+                  <Box className="chat-empty-state">
+                    Select a chat or start a new one
                   </Box>
-                </Window>
-              </Channel>
-            ) : (
-              <Box className="chat-empty-state">
-                Select a chat or start a new one
+                )}
               </Box>
-            )}
+            </Chat>
           </Box>
-        </Chat>
-      </Box>
 
-      <NewChatDialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        client={client}
-        currentUser={user}
-        clientReady={clientReady}
-        onSelectChannel={handleSelectChannel}
-      />
-    </Box>
+          <NewChatDialog
+            open={dialogOpen}
+            onClose={() => setDialogOpen(false)}
+            client={client}
+            currentUser={user}
+            clientReady={clientReady}
+            onSelectChannel={handleSelectChannel}
+          />
+        </Box>
+      </Box>
+    </BaseLayout>
   );
 }

--- a/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -53,21 +53,36 @@ vi.mock("../../config", () => ({
   API_URL: "http://localhost:3000",
 }));
 
+vi.mock("../../components/BaseLayout", () => ({
+  default: ({
+    children,
+    pageTitle,
+    onHeaderBack,
+    headerActions,
+  }: {
+    children: React.ReactNode
+    pageTitle?: string
+    onHeaderBack?: () => void
+    headerActions?: React.ReactNode
+  }) => (
+    <div data-testid="base-layout">
+      {pageTitle && <span>{pageTitle}</span>}
+      {onHeaderBack && (
+        <button type="button" aria-label="Back to Dashboard" onClick={onHeaderBack}>
+          Back
+        </button>
+      )}
+      {headerActions}
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("stream-chat-react", () => ({
   Chat: ({ children }: { children: React.ReactNode }) => <div data-testid="stream-chat">{children}</div>,
   Channel: ({ children }: { children: React.ReactNode }) => <div data-testid="stream-channel">{children}</div>,
   Window: ({ children }: { children: React.ReactNode }) => <div data-testid="stream-window">{children}</div>,
   MessageList: () => <div data-testid="message-list">Message List</div>,
-}));
-
-vi.mock("../../components/chat/ChatHeader", () => ({
-  default: ({ title, onNewChat, onBack }: { title: string; onNewChat: () => void; onBack: () => void }) => (
-    <div data-testid="chat-header">
-      <span>{title}</span>
-      <button onClick={onNewChat}>New Chat</button>
-      <button onClick={onBack}>Back</button>
-    </div>
-  ),
 }));
 
 vi.mock("../../components/chat/ChatSidebar", () => ({
@@ -149,7 +164,8 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByTestId("chat-header")).toBeInTheDocument();
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
+        expect(screen.getByText("Messages")).toBeInTheDocument();
       });
     });
   });
@@ -170,7 +186,7 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByTestId("chat-header")).toBeInTheDocument();
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
         expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
         expect(screen.getByTestId("stream-chat")).toBeInTheDocument();
       });
@@ -242,7 +258,7 @@ describe("ChatPage", () => {
     });
   });
 
-  describe("Chat Header", () => {
+  describe("Chat page header (BaseLayout)", () => {
     it("displays Messages title", async () => {
       mockStreamClient.userID = "user-1";
       renderChatPage();
@@ -270,10 +286,10 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByTestId("chat-header")).toBeInTheDocument();
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
       });
 
-      const backButton = screen.getByText("Back");
+      const backButton = screen.getByRole("button", { name: "Back to Dashboard" });
       await user.click(backButton);
 
       expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
@@ -288,10 +304,10 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByText("New Chat")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Start New Chat" })).toBeInTheDocument();
       });
 
-      const newChatButton = screen.getByText("New Chat");
+      const newChatButton = screen.getByRole("button", { name: "Start New Chat" });
       await user.click(newChatButton);
 
       expect(screen.getByTestId("new-chat-dialog")).toBeInTheDocument();
@@ -304,11 +320,11 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByText("New Chat")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Start New Chat" })).toBeInTheDocument();
       });
 
       // Open dialog
-      const newChatButton = screen.getByText("New Chat");
+      const newChatButton = screen.getByRole("button", { name: "Start New Chat" });
       await user.click(newChatButton);
 
       // Close dialog
@@ -706,7 +722,7 @@ describe("ChatPage", () => {
       renderChatPage();
 
       await waitFor(() => {
-        expect(screen.getByTestId("chat-header")).toBeInTheDocument();
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
       });
 
       // Should not create a messaging channel

--- a/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -27,6 +27,9 @@ const mockStreamClient = {
   off: vi.fn(),
 };
 
+/** Reassign in tests to simulate missing Stream API key (streamClient === null). */
+let streamClientExport: typeof mockStreamClient | null = mockStreamClient;
+
 vi.mock("../../utils/auth", () => ({
   authUtils: {
     getCurrentUser: vi.fn(),
@@ -35,7 +38,7 @@ vi.mock("../../utils/auth", () => ({
 
 vi.mock("../../utils/streamClient", () => ({
   get streamClient() {
-    return mockStreamClient;
+    return streamClientExport;
   },
 }));
 
@@ -145,6 +148,7 @@ describe("ChatPage", () => {
     });
 
     // Reset stream client state
+    streamClientExport = mockStreamClient;
     mockStreamClient.userID = null;
     mockStreamClient.user = { total_unread_count: 0 };
   });
@@ -178,8 +182,18 @@ describe("ChatPage", () => {
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
     });
 
-    // Removed the "shows 'Chat Not Available' when client is null" test
-    // as testing a null client is difficult with our current mock setup
+    it("shows 'Chat Not Available' when stream client is not configured", () => {
+      streamClientExport = null;
+      renderChatPage();
+
+      expect(screen.getByText("Chat Not Available")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Stream Chat API key is not configured. Please set VITE_STREAM_API_KEY in your environment variables."
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByText("Chat", { exact: true })).toBeInTheDocument();
+    });
 
     it("renders chat interface after client is ready", async () => {
       mockStreamClient.userID = "user-1";

--- a/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -175,14 +175,21 @@ describe("ChatPage", () => {
   });
 
   describe("Loading States", () => {
-    it("shows loading spinner when client is not ready", () => {
+    it("shows loading spinner when client is not ready", async () => {
+      const user = userEvent.setup();
       mockStreamClient.userID = null;
       renderChatPage();
 
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
+      expect(document.querySelector(".chat-loading-container")).toBeInTheDocument();
+
+      const back = screen.getByRole("button", { name: "Back to Dashboard" });
+      await user.click(back);
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
     });
 
-    it("shows 'Chat Not Available' when stream client is not configured", () => {
+    it("shows 'Chat Not Available' when stream client is not configured", async () => {
+      const user = userEvent.setup();
       streamClientExport = null;
       renderChatPage();
 
@@ -193,6 +200,11 @@ describe("ChatPage", () => {
         )
       ).toBeInTheDocument();
       expect(screen.getByText("Chat", { exact: true })).toBeInTheDocument();
+      expect(document.querySelector(".chat-center-container")).toBeInTheDocument();
+
+      const back = screen.getByRole("button", { name: "Back to Dashboard" });
+      await user.click(back);
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
     });
 
     it("renders chat interface after client is ready", async () => {
@@ -524,6 +536,20 @@ describe("ChatPage", () => {
           expect.any(Function)
         );
       });
+    });
+
+    it("unsubscribes stream notification listeners on unmount", async () => {
+      mockStreamClient.userID = "user-1";
+      const { unmount } = renderChatPage();
+
+      await waitFor(() => {
+        expect(mockStreamClient.on).toHaveBeenCalled();
+      });
+
+      unmount();
+
+      expect(mockStreamClient.off).toHaveBeenCalledWith("notification.message_new", expect.any(Function));
+      expect(mockStreamClient.off).toHaveBeenCalledWith("notification.mark_read", expect.any(Function));
     });
   });
 


### PR DESCRIPTION
## Chat uses `BaseLayout` only (single header)

### Summary
Puts the dashboard chat route in the shared app shell and removes the second in-page gradient bar so navigation, notifications, and chat actions all live in one header.

### Changes
- **`ChatPage`**: Wrapped in `BaseLayout` with height tied to `--base-layout-header-height`; Stream UI fills the area below the sticky header (`ChatPage.css` uses flex instead of full `100vh` for the main column).
- **`BaseLayout`**: Added optional **`onHeaderBack`** (back control next to the page title) and **`headerActions`** (extra controls before the global Chat button). Chat uses these for **Back to Dashboard**, **Messages** (+ unread count in the title), and **Start New Chat**.
- **Removed** use of `ChatHeader` on the chat page (component file remains for its unit tests).
- **Tests**: `ChatPage` and `BaseLayout` updated for the new layout and props.

### Result
Users see one header on `/dashboard/chat`, with the same behavior as before (new chat dialog, back to dashboard, unread in title).