### PR TITLE
Hide Networking ounge channels from chat sidebar

### DIFF
--- a/frontend/src/components/__tests__/ChatSidebar.test.tsx
+++ b/frontend/src/components/__tests__/ChatSidebar.test.tsx
@@ -78,6 +78,59 @@ describe("ChatSidebar", () => {
     channelListSpy.mockRestore();
   });
 
+  it("filters out networking lounge channels via channelRenderFilterFn", () => {
+    const channelListSpy = vi.spyOn(streamChatReact, "ChannelList");
+    render(
+      <ChatSidebar
+        client={mockClient}
+        onSelectChannel={mockOnSelectChannel}
+        activeChannel={null}
+      />
+    );
+
+    const filterFn = channelListSpy.mock.calls[0]?.[0]?.channelRenderFilterFn as
+      | ((channels: any[]) => any[])
+      | undefined;
+    expect(filterFn).toBeTypeOf("function");
+
+    const channels = [
+      { id: "user1-user2", cid: "messaging:user1-user2" },
+      { id: "lounge-fair1", cid: "messaging:lounge-fair1" },
+      { id: "lounge-fair2", cid: "messaging:lounge-fair2" },
+      { id: "abc123", cid: "messaging:abc123" },
+    ];
+    const filtered = filterFn!(channels);
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((c) => c.id)).toEqual(["user1-user2", "abc123"]);
+
+    channelListSpy.mockRestore();
+  });
+
+  it("channelRenderFilterFn handles channels with missing id safely", () => {
+    const channelListSpy = vi.spyOn(streamChatReact, "ChannelList");
+    render(
+      <ChatSidebar
+        client={mockClient}
+        onSelectChannel={mockOnSelectChannel}
+        activeChannel={null}
+      />
+    );
+
+    const filterFn = channelListSpy.mock.calls[0]?.[0]?.channelRenderFilterFn as
+      | ((channels: any[]) => any[])
+      | undefined;
+    const filtered = filterFn!([
+      { cid: "messaging:no-id" },
+      { id: "lounge-fair1" },
+      { id: "regular" },
+    ]);
+
+    expect(filtered.map((c) => c.id ?? null)).toEqual([null, "regular"]);
+
+    channelListSpy.mockRestore();
+  });
+
   it("calls onSelectChannel when a channel is selected", () => {
     const channelListSpy = vi.spyOn(streamChatReact, "ChannelList");
     const mockSetActiveChannel = vi.fn();

--- a/frontend/src/components/chat/ChatSidebar.tsx
+++ b/frontend/src/components/chat/ChatSidebar.tsx
@@ -70,6 +70,9 @@ export default function ChatSidebar({
           sort={{ last_message_at: -1 as const }}
           options={{ state: true, watch: true, presence: true }}
           Preview={CustomPreview}
+          channelRenderFilterFn={(channels) =>
+            channels.filter((c) => !c.id?.startsWith("lounge-"))
+          }
         />
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- The Networking Lounge was appearing in the user's chat list. The lounge is created server-side as a Stream `messaging` channel with the user as a member, so it matched the `ChannelList` query in `ChatSidebar` (filter: `type: "messaging"` + member match) and rendered alongside DMs.
- Fixed by passing a `channelRenderFilterFn` to `ChannelList` that excludes channels whose ID starts with `lounge-` (the prefix used when the lounge is created in `backend/routes/fairs.js`). The lounge page itself is unaffected — it watches the channel directly by ID.
- Added unit tests covering the filter behavior and the `id?.startsWith` optional-chain branch.

## Files changed
- `frontend/src/components/chat/ChatSidebar.tsx` — adds the filter prop
- `frontend/src/components/__tests__/ChatSidebar.test.tsx` — 2 new tests

## Test plan
- [x] `npx vitest run src/components/__tests__/ChatSidebar.test.tsx` — all 11 tests pass
- [ ] Open the app as a student, join a fair's Networking Lounge, then open the chat page — confirm the lounge no longer appears in the sidebar
- [ ] Confirm the Networking Lounge page itself still works (messages send/receive)
- [ ] Confirm 1:1 DMs still appear in the sidebar as before

## Note
Q&A session channels (ID prefix `qna_session_`) likely have the same issue but are out of scope for this PR — happy to follow up if that's also unwanted.
