### PR TITLE
Kevin/final fixes

### DIFF
--- a/backend/__tests__/boothRatings.test.js
+++ b/backend/__tests__/boothRatings.test.js
@@ -350,7 +350,8 @@ describe("GET /api/booths/:boothId/ratings", () => {
     verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
     setupBoothsMock({
       userData: { role: "student", companyId: null },
-      boothData: { companyName: "Acme" },
+      boothData: { companyName: "Acme", companyId: "company-1" },
+      companyData: { ownerId: "owner-uid", representativeIDs: [] },
     });
     const res = await request(app)
       .get("/api/booths/booth-1/ratings")
@@ -362,8 +363,8 @@ describe("GET /api/booths/:boothId/ratings", () => {
     verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
     setupBoothsMock({
       userData: { role: "companyOwner", companyId: "company-1" },
-      boothData: { companyName: "Acme" },
-      companyData: { boothId: "different-booth" },
+      boothData: { companyName: "Acme", companyId: "company-2" },
+      companyData: { ownerId: "someone-else", representativeIDs: [] },
     });
     const res = await request(app)
       .get("/api/booths/booth-1/ratings")
@@ -375,8 +376,8 @@ describe("GET /api/booths/:boothId/ratings", () => {
     verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
     setupBoothsMock({
       userData: { role: "companyOwner", companyId: "company-1" },
-      boothData: { companyName: "Acme" },
-      companyData: { boothId: "booth-1" },
+      boothData: { companyName: "Acme", companyId: "company-1" },
+      companyData: { ownerId: "owner-uid", representativeIDs: [] },
       ratingsSnap: [
         { id: "s1", data: () => ({ rating: 5, comment: "Excellent", createdAt: { toMillis: () => 2000 } }) },
       ],

--- a/backend/__tests__/boothVisitorsIntegrationTests.test.js
+++ b/backend/__tests__/boothVisitorsIntegrationTests.test.js
@@ -266,18 +266,36 @@ function setupDbForBoothVisitors(options = {}) {
     visitors = [],
     userCompanyId = "company-A",
     boothCompanyId = "company-A",
+    authUserId = "company-rep",
+    companyOwnerId,
+    companyRepresentativeIds = [],
   } = options;
+
+  const ownerId = companyOwnerId !== undefined ? companyOwnerId : authUserId;
+  const representativeIDs = companyRepresentativeIds;
 
   const visitorDocs = visitors.map((v) =>
     mockDocSnap(v, true, v.studentId)
   );
 
   db.collection.mockImplementation((collName) => {
+    if (collName === "companies") {
+      return {
+        doc: jest.fn((cid) => ({
+          get: jest.fn().mockResolvedValue(
+            cid === boothCompanyId
+              ? mockDocSnap({ ownerId, representativeIDs }, true, cid)
+              : mockDocSnap(null, false, cid)
+          ),
+        })),
+      };
+    }
+
     if (collName === "users") {
       return {
         doc: jest.fn(() => ({
           get: jest.fn().mockResolvedValue(
-            mockDocSnap({ companyId: userCompanyId }, true, "company-rep")
+            mockDocSnap({ companyId: userCompanyId }, true, authUserId)
           ),
         })),
       };
@@ -584,21 +602,17 @@ describe("GET /api/booth-visitors/:boothId - Company Analytics with Filtering/So
     expect(res.status).toBe(404);
   });
 
-  it("returns 404 when user not found", async () => {
+  it("returns 400 when booth has no associated company", async () => {
     db.collection.mockImplementation((collName) => {
-      if (collName === "users") {
-        return {
-          doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(mockDocSnap(null, false)),
-          })),
-        };
-      }
       if (collName === "booths") {
         return {
           doc: jest.fn(() => ({
             get: jest.fn().mockResolvedValue(
-              mockDocSnap({ companyId: "company-A" }, true)
+              mockDocSnap({ currentVisitors: [] }, true, "booth-123")
             ),
+            collection: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockQuerySnap([])),
+            })),
           })),
         };
       }
@@ -614,13 +628,16 @@ describe("GET /api/booth-visitors/:boothId - Company Analytics with Filtering/So
       .get("/api/booth-visitors/booth-123")
       .set("Authorization", companyAuth());
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no associated company/i);
   });
 
-  it("returns 403 when company IDs don't match", async () => {
+  it("returns 403 when user is not owner or representative of booth company", async () => {
     setupDbForBoothVisitors({
       userCompanyId: "company-A",
       boothCompanyId: "company-B",
+      companyOwnerId: "some-other-owner",
+      companyRepresentativeIds: [],
     });
 
     const res = await request(app)
@@ -628,6 +645,22 @@ describe("GET /api/booth-visitors/:boothId - Company Analytics with Filtering/So
       .set("Authorization", companyAuth());
 
     expect(res.status).toBe(403);
+  });
+
+  it("returns 200 when user.companyId differs but user is a representative of booth company", async () => {
+    setupDbForBoothVisitors({
+      userCompanyId: "company-A",
+      boothCompanyId: "company-B",
+      companyOwnerId: "some-owner",
+      companyRepresentativeIds: ["company-rep"],
+    });
+
+    const res = await request(app)
+      .get("/api/booth-visitors/booth-123")
+      .set("Authorization", companyAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
   });
 
   it("returns all visitors when authorized", async () => {

--- a/backend/__tests__/jobInvitations.test.js
+++ b/backend/__tests__/jobInvitations.test.js
@@ -159,6 +159,10 @@ describe("POST /api/job-invitations/send", () => {
     setupDbMock({
       jobs: { docData: { companyId: "c1", name: "Developer" }, docExists: true },
       users: { docData: { role: "companyOwner", companyId: "c2" }, docExists: true },
+      companies: {
+        docData: { ownerId: "someone-else", representativeIDs: [] },
+        docExists: true,
+      },
     });
 
     const res = await request(app)
@@ -211,7 +215,13 @@ describe("POST /api/job-invitations/send", () => {
       if (name === "companies") {
         return {
           doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(mockDocSnap({ companyName: "Tech Corp" }, true, "c1")),
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap(
+                { companyName: "Tech Corp", ownerId: "u1", representativeIDs: [] },
+                true,
+                "c1"
+              )
+            ),
           })),
         };
       }
@@ -512,6 +522,15 @@ describe("GET /api/job-invitations/sent", () => {
           get: jest.fn().mockResolvedValue(mockQuerySnap([])),
         };
       }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "u1", representativeIDs: [] }, true, "c1")
+            ),
+          })),
+        };
+      }
       return {
         doc: jest.fn(() => ({
           get: jest.fn().mockResolvedValue(mockDocSnap({ role: "companyOwner", companyId: "c1" }, true)),
@@ -603,6 +622,15 @@ describe("GET /api/job-invitations/stats/:jobId", () => {
         return {
           doc: jest.fn(() => ({
             get: jest.fn().mockResolvedValue(mockDocSnap({ role: "companyOwner", companyId: "c1" }, true, "u1")),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "u1", representativeIDs: [] }, true, "c1")
+            ),
           })),
         };
       }
@@ -698,6 +726,15 @@ describe("GET /api/job-invitations/details/:jobId", () => {
               ),
             };
           }),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "u1", representativeIDs: [] }, true, "c1")
+            ),
+          })),
         };
       }
       return {

--- a/backend/__tests__/routes/booths.test.js
+++ b/backend/__tests__/routes/booths.test.js
@@ -662,22 +662,22 @@ describe("GET /api/booth-visitors/:boothId", () => {
     expect(res.body.error).toMatch(/Booth not found/i);
   });
 
-  it("returns 404 when user does not exist", async () => {
+  it("returns 400 when booth has no associated company", async () => {
     mockCollections({
-      boothDoc: mockDocSnap({ companyId: "company-1" }, true, "booth-1"),
-      userDoc: mockDocSnap(null, false),
+      boothDoc: mockDocSnap({ currentVisitors: [] }, true, "booth-1"),
+      companyDoc: mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true, "company-1"),
     });
     const res = await request(app)
       .get("/api/booth-visitors/booth-1")
       .set("Authorization", authHeader());
-    expect(res.status).toBe(404);
-    expect(res.body.error).toMatch(/User not found/i);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no associated company/i);
   });
 
-  it("returns 403 when user belongs to a different company", async () => {
+  it("returns 403 when user is not owner or representative of booth company", async () => {
     mockCollections({
       boothDoc: mockDocSnap({ companyId: "other-company" }, true, "booth-1"),
-      userDoc: mockDocSnap({ companyId: "company-1" }, true, "test-uid"),
+      companyDoc: mockDocSnap({ ownerId: "someone-else", representativeIDs: [] }, true, "other-company"),
     });
     const res = await request(app)
       .get("/api/booth-visitors/booth-1")
@@ -702,6 +702,15 @@ describe("GET /api/booth-visitors/:boothId", () => {
     );
 
     db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true, "company-1")
+            ),
+          })),
+        };
+      }
       if (name === "booths") {
         const studentVisitsRef = {
           get: jest.fn().mockResolvedValue(mockQuerySnap([visitDoc])),
@@ -712,15 +721,6 @@ describe("GET /api/booth-visitors/:boothId", () => {
               mockDocSnap({ companyId: "company-1", currentVisitors: [] }, true, "booth-1")
             ),
             collection: jest.fn(() => studentVisitsRef),
-          })),
-        };
-      }
-      if (name === "users") {
-        return {
-          doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(
-              mockDocSnap({ companyId: "company-1" }, true, "test-uid")
-            ),
           })),
         };
       }
@@ -749,6 +749,15 @@ describe("GET /api/booth-visitors/:boothId", () => {
     );
 
     db.collection.mockImplementation((name) => {
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true, "company-1")
+            ),
+          })),
+        };
+      }
       if (name === "booths") {
         return {
           doc: jest.fn(() => ({
@@ -760,9 +769,6 @@ describe("GET /api/booth-visitors/:boothId", () => {
             })),
           })),
         };
-      }
-      if (name === "users") {
-        return { doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap({ companyId: "company-1" }, true)) })) };
       }
       if (name === "fairs") {
         return { get: jest.fn().mockResolvedValue(mockQuerySnap([])) };
@@ -1058,35 +1064,8 @@ describe("GET /api/booths/:boothId/ratings", () => {
     expect(res.body.totalRatings).toBe(1);
   });
 
-  it("returns 404 when non-admin user does not exist", async () => {
-    mockCollections({
-      boothDoc: mockDocSnap({ companyId: "company-1" }, true, "booth-1"),
-      userDoc: mockDocSnap(null, false),
-    });
+  it("returns 403 when non-admin is not owner or representative of booth company", async () => {
     verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
-
-    const res = await request(app)
-      .get("/api/booths/booth-1/ratings")
-      .set("Authorization", authHeader());
-    expect(res.status).toBe(404);
-    expect(res.body.error).toMatch(/User not found/i);
-  });
-
-  it("returns 403 when non-admin user has no companyId", async () => {
-    mockCollections({
-      boothDoc: mockDocSnap({ companyId: "company-1" }, true, "booth-1"),
-      userDoc: mockDocSnap({ role: "student" }, true), // no companyId
-    });
-    verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
-
-    const res = await request(app)
-      .get("/api/booths/booth-1/ratings")
-      .set("Authorization", authHeader());
-    expect(res.status).toBe(403);
-    expect(res.body.error).toMatch(/Unauthorized/i);
-  });
-
-  it("returns 403 when company does not own the booth", async () => {
     db.collection.mockImplementation((name) => {
       if (name === "booths") {
         return {
@@ -1100,27 +1079,16 @@ describe("GET /api/booths/:boothId/ratings", () => {
           })),
         };
       }
-      if (name === "users") {
-        return {
-          doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(
-              mockDocSnap({ companyId: "company-2" }, true, "test-uid")
-            ),
-          })),
-        };
-      }
       if (name === "companies") {
         return {
           doc: jest.fn(() => ({
             get: jest.fn().mockResolvedValue(
-              // boothId does NOT match
-              mockDocSnap({ boothId: "some-other-booth" }, true, "company-2")
+              mockDocSnap({ ownerId: "someone-else", representativeIDs: [] }, true, "company-1")
             ),
           })),
         };
       }
     });
-    verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
 
     const res = await request(app)
       .get("/api/booths/booth-1/ratings")
@@ -1129,7 +1097,8 @@ describe("GET /api/booths/:boothId/ratings", () => {
     expect(res.body.error).toMatch(/Unauthorized/i);
   });
 
-  it("returns ratings for authorized company rep", async () => {
+  it("returns 200 when non-admin is representative though user.companyId is a different company", async () => {
+    verifyAdmin.mockResolvedValue({ error: "Not admin", status: 403 });
     const ratingDoc = mockDocSnap(
       { rating: 3, comment: null, createdAt: { toMillis: () => 2000000 } },
       true,
@@ -1152,7 +1121,7 @@ describe("GET /api/booths/:boothId/ratings", () => {
         return {
           doc: jest.fn(() => ({
             get: jest.fn().mockResolvedValue(
-              mockDocSnap({ companyId: "company-1" }, true, "test-uid")
+              mockDocSnap({ companyId: "company-2", role: "representative" }, true, "test-uid")
             ),
           })),
         };
@@ -1161,7 +1130,50 @@ describe("GET /api/booths/:boothId/ratings", () => {
         return {
           doc: jest.fn(() => ({
             get: jest.fn().mockResolvedValue(
-              mockDocSnap({ boothId: "booth-1" }, true, "company-1")
+              mockDocSnap(
+                { ownerId: "other-boss", representativeIDs: ["test-uid"] },
+                true,
+                "company-1"
+              )
+            ),
+          })),
+        };
+      }
+    });
+
+    const res = await request(app)
+      .get("/api/booths/booth-1/ratings")
+      .set("Authorization", authHeader());
+    expect(res.status).toBe(200);
+    expect(res.body.totalRatings).toBe(1);
+    expect(res.body.averageRating).toBe(3);
+    expect(res.body.ratings[0]).not.toHaveProperty("studentId");
+  });
+
+  it("returns ratings for authorized company owner", async () => {
+    const ratingDoc = mockDocSnap(
+      { rating: 3, comment: null, createdAt: { toMillis: () => 2000000 } },
+      true,
+      "rating-2"
+    );
+    db.collection.mockImplementation((name) => {
+      if (name === "booths") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ companyId: "company-1" }, true, "booth-1")
+            ),
+            collection: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockQuerySnap([ratingDoc])),
+            })),
+          })),
+        };
+      }
+      if (name === "companies") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ ownerId: "test-uid", representativeIDs: [] }, true, "company-1")
             ),
           })),
         };

--- a/backend/__tests__/routes/jobInvitations.test.js
+++ b/backend/__tests__/routes/jobInvitations.test.js
@@ -56,6 +56,17 @@ const studentUserData = { role: "student" };
 const companyData = { companyName: "Acme Corp", boothId: "booth-1", ownerId: "rep-1", representativeIDs: ["rep-2"] };
 const jobData = { companyId: "company-1", name: "SWE", description: "Build stuff", majorsAssociated: "CS" };
 
+/** verifyRepOrOwner + checkCompanyAuthorization reads companies/{job's companyId} */
+function companiesCollectionDefault() {
+  return {
+    doc: jest.fn((cid) => ({
+      get: jest.fn().mockResolvedValue(
+        cid === "company-1" ? mockDocSnap(companyData, true, cid) : mockDocSnap(null, false, cid)
+      ),
+    })),
+  };
+}
+
 const invitationData = {
   jobId: "job-1",
   companyId: "company-1",
@@ -191,7 +202,7 @@ describe("POST /api/job-invitations/send", () => {
     expect(res.body.error).toMatch(/Only representatives and company owners/i);
   });
 
-  it("returns 403 when rep belongs to a different company", async () => {
+  it("returns 403 when user is not owner or representative for the job's company", async () => {
     db.collection.mockImplementation((name) => {
       if (name === "jobs") {
         return { doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(mockDocSnap(jobData)) })) };
@@ -199,16 +210,21 @@ describe("POST /api/job-invitations/send", () => {
       if (name === "users") {
         return {
           doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(mockDocSnap({ role: "representative", companyId: "other-company" })),
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "representative", companyId: "other-company" }, true, "stranger-rep")
+            ),
           })),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 
     const res = await request(app)
       .post("/api/job-invitations/send")
       .set("Authorization", AUTH)
-      .send(validBody);
+      .send({ ...validBody, userId: "stranger-rep" });
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/You can only send invitations for your own company/i);
   });
@@ -230,6 +246,9 @@ describe("POST /api/job-invitations/send", () => {
             return { get: jest.fn().mockResolvedValue(mockDocSnap(null, false)) };
           }),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 
@@ -257,6 +276,9 @@ describe("POST /api/job-invitations/send", () => {
             return { get: jest.fn().mockResolvedValue(mockDocSnap({ role: "representative" })) };
           }),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 
@@ -291,6 +313,9 @@ describe("POST /api/job-invitations/send", () => {
         return {
           doc: jest.fn(() => ({ id: "new-inv-id", set: jest.fn() })),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
     db.batch = jest.fn(() => batch);
@@ -523,18 +548,25 @@ describe("GET /api/job-invitations/sent", () => {
     expect(res.body.error).toMatch(/Only representatives and company owners/i);
   });
 
-  it("returns 403 when rep belongs to a different company than queried companyId", async () => {
+  it("returns 403 when user cannot access the requested companyId filter", async () => {
     db.collection.mockImplementation((name) => {
       if (name === "users") {
         return {
           doc: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue(mockDocSnap({ role: "representative", companyId: "other-company" })),
+            get: jest.fn().mockResolvedValue(
+              mockDocSnap({ role: "representative", companyId: "other-company" }, true, "stranger-rep")
+            ),
           })),
         };
       }
+      if (name === "companies") {
+        return companiesCollectionDefault();
+      }
     });
 
-    const res = await request(app).get("/api/job-invitations/sent?userId=rep-1&companyId=company-1").set("Authorization", AUTH);
+    const res = await request(app)
+      .get("/api/job-invitations/sent?userId=stranger-rep&companyId=company-1")
+      .set("Authorization", AUTH);
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/You can only send invitations for your own company/i);
   });
@@ -599,6 +631,9 @@ describe("GET /api/job-invitations/sent", () => {
             get: jest.fn().mockResolvedValue(mockDocSnap({ name: "SWE" }, true, "job-1")),
           })),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 
@@ -852,6 +887,9 @@ describe("GET /api/job-invitations/stats/:jobId", () => {
           get: jest.fn().mockResolvedValue(querySnap),
         };
       }
+      if (name === "companies") {
+        return companiesCollectionDefault();
+      }
     });
 
     const res = await request(app).get("/api/job-invitations/stats/job-1?userId=rep-1").set("Authorization", AUTH);
@@ -882,6 +920,9 @@ describe("GET /api/job-invitations/stats/:jobId", () => {
           where: jest.fn().mockReturnThis(),
           get: jest.fn().mockResolvedValue(querySnap),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 
@@ -979,6 +1020,9 @@ describe("GET /api/job-invitations/details/:jobId", () => {
           where: jest.fn().mockReturnThis(),
           get: jest.fn().mockResolvedValue(querySnap),
         };
+      }
+      if (name === "companies") {
+        return companiesCollectionDefault();
       }
     });
 

--- a/backend/helpers.js
+++ b/backend/helpers.js
@@ -273,9 +273,16 @@ async function verifyRepOrOwner(userId, companyId) {
     return { error: "Only representatives and company owners can send invitations", status: 403 };
   }
 
-  // If companyId is provided, verify the user belongs to that company
-  if (companyId && userData.companyId !== companyId) {
-    return { error: "You can only send invitations for your own company", status: 403 };
+  // If companyId is provided, verify owner/representative on that company document (not user.companyId
+  // alone — users linked to multiple companies often keep one primary companyId on the user doc).
+  if (companyId) {
+    const auth = await checkCompanyAuthorization(companyId, userId);
+    if (!auth.authorized) {
+      const status = auth.error === "Invalid company ID" ? 404 : 403;
+      const error =
+        status === 404 ? "Company not found" : "You can only send invitations for your own company";
+      return { error, status };
+    }
   }
 
   return null;

--- a/backend/routes/booths.js
+++ b/backend/routes/booths.js
@@ -443,18 +443,15 @@ router.get("/booth-visitors/:boothId", verifyFirebaseToken, async (req, res) => 
     const boothData = boothResult.data;
     const boothCompanyId = boothData.companyId;
 
-    // Get user data to verify authorization
-    const userDoc = await db.collection("users").doc(userId).get();
-    if (!userDoc.exists) {
-      return res.status(404).json({ success: false, error: "User not found" });
+    if (!boothCompanyId) {
+      return res.status(400).json({ success: false, error: "Booth has no associated company" });
     }
 
-    const userData = userDoc.data();
-    const userCompanyId = userData.companyId;
-
-    // Check authorization: user's company must match booth's company
-    if (userCompanyId !== boothCompanyId) {
-      console.log(`[GET-VISITORS] Auth failed: company mismatch`);
+    // Owner or representative for this booth's company (not user.profile companyId alone —
+    // users linked to multiple companies often keep a single primary companyId on the user doc)
+    const authResult = await checkCompanyAuthorization(boothCompanyId, userId);
+    if (!authResult.authorized) {
+      console.log(`[GET-VISITORS] Auth failed: ${authResult.error}`);
       return res.status(403).json({ success: false, error: "Not authorized to view booth visitors" });
     }
 
@@ -609,13 +606,12 @@ router.get("/booths/:boothId/ratings", verifyFirebaseToken, async (req, res) => 
 
     const adminErr = await verifyAdmin(userId);
     if (adminErr) {
-      // Not admin — must be owner/rep of the company that owns this booth
-      const userDoc = await db.collection("users").doc(userId).get();
-      if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
-      const companyId = userDoc.data().companyId;
-      if (!companyId) return res.status(403).json({ error: "Unauthorized" });
-      const companyDoc = await db.collection("companies").doc(companyId).get();
-      if (!companyDoc.exists || companyDoc.data().boothId !== boothId) {
+      const boothCompanyId = boothDoc.data().companyId;
+      if (!boothCompanyId) {
+        return res.status(403).json({ error: "Unauthorized" });
+      }
+      const authResult = await checkCompanyAuthorization(boothCompanyId, userId);
+      if (!authResult.authorized) {
         return res.status(403).json({ error: "Unauthorized" });
       }
     }

--- a/frontend/src/__tests__/StudentProfileCard.test.tsx
+++ b/frontend/src/__tests__/StudentProfileCard.test.tsx
@@ -1,8 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import StudentProfileCard from "../components/StudentProfileCard"
 import * as authUtilsModule from "../utils/auth"
 import * as firestoreModule from "firebase/firestore"
+
+const navMock = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}))
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>()
+  return {
+    ...actual,
+    useNavigate: () => navMock.navigate,
+  }
+})
 
 // Mock Firestore
 vi.mock("firebase/firestore", () => ({
@@ -17,6 +30,7 @@ vi.mock("../firebase", () => ({
 vi.mock("../utils/auth", () => ({
   authUtils: {
     getIdToken: vi.fn(),
+    getCurrentUser: vi.fn(),
   },
 }))
 
@@ -24,6 +38,8 @@ describe("StudentProfileCard", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     global.fetch = vi.fn()
+    navMock.navigate.mockClear()
+    vi.mocked(authUtilsModule.authUtils.getCurrentUser).mockReturnValue(null)
   })
 
   describe("Loading State", () => {
@@ -635,6 +651,117 @@ describe("StudentProfileCard", () => {
         const alert = container.querySelector("[role='alert']")
         expect(alert).toBeTruthy()
       })
+    })
+  })
+
+  describe("Employer messaging", () => {
+    beforeEach(() => {
+      vi.mocked(authUtilsModule.authUtils.getCurrentUser).mockReturnValue({
+        uid: "employer-1",
+        email: "employer@example.com",
+      } as any)
+    })
+
+    it("shows Open messages when enableEmployerMessaging is true", async () => {
+      const mockGetDoc = vi.mocked(firestoreModule.getDoc)
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+        }),
+      } as any)
+
+      render(<StudentProfileCard studentId="student-123" enableEmployerMessaging />)
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /open messages/i })).toBeInTheDocument()
+      })
+    })
+
+    it("navigates to chat with dmStudentId when Open messages is clicked", async () => {
+      const user = userEvent.setup()
+      const mockGetDoc = vi.mocked(firestoreModule.getDoc)
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+        }),
+      } as any)
+
+      render(<StudentProfileCard studentId="student-123" enableEmployerMessaging />)
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /open messages/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole("button", { name: /open messages/i }))
+
+      expect(navMock.navigate).toHaveBeenCalledWith("/dashboard/chat", {
+        state: { dmStudentId: "student-123" },
+      })
+    })
+
+    it("does not show Open messages when viewer is the same user as the profile", async () => {
+      vi.mocked(authUtilsModule.authUtils.getCurrentUser).mockReturnValue({
+        uid: "student-123",
+        email: "self@example.com",
+      } as any)
+
+      const mockGetDoc = vi.mocked(firestoreModule.getDoc)
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          firstName: "Self",
+          lastName: "User",
+          email: "self@example.com",
+        }),
+      } as any)
+
+      render(<StudentProfileCard studentId="student-123" enableEmployerMessaging />)
+
+      await waitFor(() => {
+        expect(screen.getByText("Self User")).toBeInTheDocument()
+      })
+
+      expect(screen.queryByRole("button", { name: /open messages/i })).not.toBeInTheDocument()
+    })
+
+    it("calls onBeforeNavigateToChat before navigating", async () => {
+      const user = userEvent.setup()
+      const onBefore = vi.fn()
+      const mockGetDoc = vi.mocked(firestoreModule.getDoc)
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+        }),
+      } as any)
+
+      render(
+        <StudentProfileCard
+          studentId="student-123"
+          enableEmployerMessaging
+          onBeforeNavigateToChat={onBefore}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /open messages/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole("button", { name: /open messages/i }))
+
+      expect(onBefore).toHaveBeenCalled()
+      expect(navMock.navigate).toHaveBeenCalled()
+      expect(onBefore.mock.invocationCallOrder[0]).toBeLessThan(
+        navMock.navigate.mock.invocationCallOrder[0]!
+      )
     })
   })
 

--- a/frontend/src/components/StudentProfileCard.tsx
+++ b/frontend/src/components/StudentProfileCard.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
-import { Box, Typography, CircularProgress, Alert, Chip, Paper, Button } from "@mui/material"
+import { useNavigate } from "react-router-dom"
+import { Box, Typography, CircularProgress, Alert, Chip, Paper, Button, Divider } from "@mui/material"
 import LinkedInIcon from "@mui/icons-material/LinkedIn"
+import ChatIcon from "@mui/icons-material/Chat"
 import { doc, getDoc } from "firebase/firestore"
 import { db } from "../firebase"
 import { authUtils } from "../utils/auth"
@@ -29,9 +31,23 @@ interface StudentProfile {
 
 interface Props {
   readonly studentId: string
+  /** When true, show employer action to open Stream DM with this student (from shortlist, visitor analytics, etc.). */
+  readonly enableEmployerMessaging?: boolean
+  /** Called before navigating to chat (e.g. close parent dialog). */
+  readonly onBeforeNavigateToChat?: () => void
 }
 
-export default function StudentProfileCard({ studentId }: Props) {
+export default function StudentProfileCard({
+  studentId,
+  enableEmployerMessaging = false,
+  onBeforeNavigateToChat,
+}: Props) {
+  const navigate = useNavigate()
+  const viewer = authUtils.getCurrentUser()
+  const canShowMessaging = Boolean(
+    enableEmployerMessaging && viewer?.uid && studentId !== viewer.uid
+  )
+
   const [profile, setProfile] = useState<StudentProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
@@ -286,6 +302,36 @@ export default function StudentProfileCard({ studentId }: Props) {
             </Typography>
           )}
         </Box>
+      )}
+
+      {canShowMessaging && (
+        <>
+          <Divider sx={{ my: 2 }} />
+          <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: "bold", mb: 1 }}>
+              Messages
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              Opens your Messages view with this student. If you do not already have a private channel, one is created
+              automatically.
+            </Typography>
+            <Button
+              type="button"
+              variant="contained"
+              startIcon={<ChatIcon />}
+              onClick={() => {
+                onBeforeNavigateToChat?.()
+                navigate("/dashboard/chat", { state: { dmStudentId: studentId } })
+              }}
+              sx={{
+                background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+                fontWeight: 600,
+              }}
+            >
+              Open messages
+            </Button>
+          </Box>
+        </>
       )}
     </Box>
   )

--- a/frontend/src/components/videoChat/ShortlistManager.tsx
+++ b/frontend/src/components/videoChat/ShortlistManager.tsx
@@ -36,12 +36,13 @@ interface ShortlistEntry {
 
 interface ShortlistManagerProps {
   onScheduleCall?: (studentId: string, studentName: string) => void;
+  onViewStudent?: (studentId: string) => void;
 }
 
 /**
  * ShortlistManager Component - Manage employer's candidate shortlist
  */
-export function ShortlistManager({ onScheduleCall }: Readonly<ShortlistManagerProps>) {
+export function ShortlistManager({ onScheduleCall, onViewStudent }: Readonly<ShortlistManagerProps>) {
   const [shortlist, setShortlist] = useState<ShortlistEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -205,9 +206,10 @@ export function ShortlistManager({ onScheduleCall }: Readonly<ShortlistManagerPr
                   edge="end"
                   size="small"
                   title="Schedule call"
-                  onClick={() =>
-                    onScheduleCall?.(entry.studentId, entry.studentName)
-                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onScheduleCall?.(entry.studentId, entry.studentName);
+                  }}
                 >
                   <EventAvailableIcon />
                 </IconButton>
@@ -215,14 +217,17 @@ export function ShortlistManager({ onScheduleCall }: Readonly<ShortlistManagerPr
                   edge="end"
                   size="small"
                   color="error"
-                  onClick={() => handleRemove(entry.studentId)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleRemove(entry.studentId);
+                  }}
                 >
                   <DeleteIcon />
                 </IconButton>
               </Stack>
             }
           >
-            <ListItemButton>
+            <ListItemButton onClick={() => onViewStudent?.(entry.studentId)}>
               <ListItemText
                 primary={
                   <Stack direction="row" spacing={1} alignItems="center">

--- a/frontend/src/components/videoChat/__tests__/ShortlistManager.test.tsx
+++ b/frontend/src/components/videoChat/__tests__/ShortlistManager.test.tsx
@@ -184,4 +184,30 @@ describe("ShortlistManager", () => {
 
     expect(onSchedule).toHaveBeenCalledWith("stu-1", "Sam");
   });
+
+  it("calls onViewStudent when a shortlist row is clicked", async () => {
+    const onViewStudent = vi.fn();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        shortlist: [
+          {
+            studentId: "stu-1",
+            studentName: "Sam",
+            studentEmail: "sam@test.com",
+            notes: "",
+            addedAt: 1,
+          },
+        ],
+      }),
+    });
+
+    const user = userEvent.setup();
+    render(<ShortlistManager onViewStudent={onViewStudent} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Sam/i })).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /Sam/i }));
+
+    expect(onViewStudent).toHaveBeenCalledWith("stu-1");
+  });
 });

--- a/frontend/src/pages/BoothVisitorsPage.tsx
+++ b/frontend/src/pages/BoothVisitorsPage.tsx
@@ -433,7 +433,11 @@ export default function BoothVisitorsPage() {
         </DialogTitle>
         <DialogContent sx={{ pt: 3 }}>
           {selectedStudent && (
-            <StudentProfileCard studentId={selectedStudent.studentId} />
+            <StudentProfileCard
+              studentId={selectedStudent.studentId}
+              enableEmployerMessaging
+              onBeforeNavigateToChat={() => setProfileDialogOpen(false)}
+            />
           )}
         </DialogContent>
         <DialogActions>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -22,6 +22,7 @@ import BaseLayout from "../components/BaseLayout";
 import { authUtils } from "../utils/auth";
 import { auth } from "../firebase";
 import { streamClient } from "../utils/streamClient";
+import { getOrCreateDirectChannel } from "../utils/chat";
 import "./ChatPage.css";
 
 const CHAT_SHELL_SX = {
@@ -34,6 +35,8 @@ export default function ChatPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const repIdFromBooth = location.state?.repId || null;
+  const dmStudentId =
+    typeof location.state?.dmStudentId === "string" ? location.state.dmStudentId : null;
 
   const [clientReady, setClientReady] = useState(false);
   const [activeChannel, setActiveChannel] = useState<StreamChannel | null>(null);
@@ -165,6 +168,30 @@ export default function ChatPage() {
 
     startDM();
 }, [clientReady, repIdFromBooth, client]);
+
+  /*
+  ============================================================
+   OPEN DM FROM SHORTLIST / VISITOR PROFILE (stable channel id)
+  ============================================================
+  */
+  useEffect(() => {
+    if (!clientReady) return;
+    if (!client?.userID) return;
+    if (!dmStudentId) return;
+    if (dmStudentId === client.userID) return;
+
+    const openStudentDm = async () => {
+      try {
+        const channel = await getOrCreateDirectChannel(client.userID, dmStudentId);
+        setActiveChannel(channel);
+        navigate(`${location.pathname}${location.search}`, { replace: true, state: {} });
+      } catch (err) {
+        console.error("CHAT: open student DM failed", err);
+      }
+    };
+
+    void openStudentDm();
+  }, [clientReady, dmStudentId, client, navigate, location.pathname, location.search]);
 
 
   /* Select a channel */

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -176,13 +176,14 @@ export default function ChatPage() {
   */
   useEffect(() => {
     if (!clientReady) return;
-    if (!client?.userID) return;
+    const streamUserId = client?.userID;
+    if (!streamUserId) return;
     if (!dmStudentId) return;
-    if (dmStudentId === client.userID) return;
+    if (dmStudentId === streamUserId) return;
 
     const openStudentDm = async () => {
       try {
-        const channel = await getOrCreateDirectChannel(client.userID, dmStudentId);
+        const channel = await getOrCreateDirectChannel(streamUserId, dmStudentId);
         setActiveChannel(channel);
         navigate(`${location.pathname}${location.search}`, { replace: true, state: {} });
       } catch (err) {

--- a/frontend/src/pages/Company.tsx
+++ b/frontend/src/pages/Company.tsx
@@ -662,7 +662,7 @@ function BoothManagementCard({ companyId, navigate }: Readonly<{
                   </Typography>
                 )}
               </Box>
-              <Box sx={{ display: "flex", gap: 1 }}>
+              <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "flex-end" }}>
                 <Button
                   size="small"
                   startIcon={<EditIcon />}
@@ -670,6 +670,14 @@ function BoothManagementCard({ companyId, navigate }: Readonly<{
                   sx={{ color: "#388560" }}
                 >
                   Edit
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<BarChartIcon />}
+                  onClick={() => navigate(`/booth/${booth.id}/visitors`)}
+                  sx={{ color: "#388560" }}
+                >
+                  Visitor analytics
                 </Button>
                 <Button
                   size="small"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import CalendarMonthIcon from "@mui/icons-material/CalendarMonth"
 import MailIcon from "@mui/icons-material/Mail"
 import VideoCallIcon from "@mui/icons-material/VideoCall"
 import GroupsIcon from "@mui/icons-material/Groups"
+import HistoryIcon from "@mui/icons-material/History"
 import EventList from "../components/EventList"
 import BaseLayout from "../components/BaseLayout"
 import FairAnnouncementsBanner from "../components/FairAnnouncementsBanner"
@@ -433,18 +434,18 @@ function StudentSection({
           <DashboardCard
             icon={<EventIcon sx={{ fontSize: 32, color: "#388560" }} />}
             title="Browse Career Fairs"
-            description="View all available virtual career fairs and browse company booths within each one."
+            description="View all virtual career fairs. Open a fair to browse exhibitor booths, jobs, and employer profiles in one place."
             buttonLabel="View All Fairs"
             buttonOnClick={() => navigate("/fairs")}
           />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <DashboardCard
-            icon={<BusinessIcon sx={{ fontSize: 32, color: "#b03a6c" }} />}
-            title="Browse Company Booths"
-            description="Browse live career fairs and explore opportunities from top companies at virtual career fairs."
-            buttonLabel="Browse All Fairs"
-            buttonOnClick={() => navigate("/fairs")}
+            icon={<HistoryIcon sx={{ fontSize: 32, color: "#b03a6c" }} />}
+            title="Booth History"
+            description="See fairs and booths you have already visited and review your visit history."
+            buttonLabel="View Booth History"
+            buttonOnClick={() => navigate("/dashboard/booth-history")}
             colorTheme="pink"
           />
         </Grid>
@@ -539,9 +540,8 @@ function StatsSection({
 }
 
 // Component for Company Owner section
-function CompanyOwnerSection({ navigate, isLive, totalRepresentatives, enrolledFairCount }: Readonly<{
+function CompanyOwnerSection({ navigate, totalRepresentatives, enrolledFairCount }: Readonly<{
   navigate: ReturnType<typeof useNavigate>
-  isLive: boolean
   totalRepresentatives: number
   enrolledFairCount: number
 }>) {
@@ -552,7 +552,7 @@ function CompanyOwnerSection({ navigate, isLive, totalRepresentatives, enrolledF
           Company Management
         </Typography>
       <Grid container spacing={3}>
-        <Grid size={{ xs: 12, sm: 6, md: 6 }}>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }}>
           <DashboardCard
             icon={<ShareIcon sx={{ fontSize: 28, color: "#388560" }} />}
             title="Manage Companies"
@@ -562,7 +562,7 @@ function CompanyOwnerSection({ navigate, isLive, totalRepresentatives, enrolledF
             fullButton
           />
         </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 6 }}>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }}>
           <DashboardCard
             icon={<CalendarMonthIcon sx={{ fontSize: 28, color: "#388560" }} />}
             title="Career Fairs"
@@ -573,7 +573,7 @@ function CompanyOwnerSection({ navigate, isLive, totalRepresentatives, enrolledF
             fullButton
           />
         </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 6 }}>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }}>
           <DashboardCard
             icon={<PeopleIcon sx={{ fontSize: 28, color: "#b03a6c" }} />}
             title="Team Members"
@@ -582,7 +582,6 @@ function CompanyOwnerSection({ navigate, isLive, totalRepresentatives, enrolledF
             colorTheme="pink"
           />
         </Grid>
-        <BrowseBoothsCard navigate={navigate} isLive={isLive} showHistory />
       </Grid>
     </Box>
     <EmployerVideoChatSection navigate={navigate} />
@@ -609,7 +608,6 @@ function renderRoleSection(
       return (
         <CompanyOwnerSection
           navigate={navigate}
-          isLive={props.isLive}
           totalRepresentatives={props.totalRepresentatives}
           enrolledFairCount={props.enrolledFairCount}
         />

--- a/frontend/src/pages/JobSearchPage.tsx
+++ b/frontend/src/pages/JobSearchPage.tsx
@@ -12,12 +12,16 @@ import {
   CircularProgress,
   Alert,
   Pagination,
+  Stack,
 } from "@mui/material"
 import WorkIcon from "@mui/icons-material/Work"
 import BusinessIcon from "@mui/icons-material/Business"
 import SearchIcon from "@mui/icons-material/Search"
 import LaunchIcon from "@mui/icons-material/Launch"
+import AssignmentIcon from "@mui/icons-material/Assignment"
 import BaseLayout from "../components/BaseLayout"
+import JobApplicationFormDialog from "../components/JobApplicationFormDialog"
+import type { ApplicationForm } from "../types/applicationForm"
 import { API_URL } from "../config"
 import { authUtils } from "../utils/auth"
 import { auth } from "../firebase"
@@ -45,6 +49,7 @@ interface SearchJob {
   description: string
   majorsAssociated: string
   applicationLink: string | null
+  applicationForm?: ApplicationForm | null
   locationIsRemote?: boolean
   locationCity?: string | null
   locationState?: string | null
@@ -63,6 +68,8 @@ export default function JobSearchPage() {
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
   const [pageSize, setPageSize] = useState(PAGE_SIZE)
+  const [applyDialogOpen, setApplyDialogOpen] = useState(false)
+  const [jobForApply, setJobForApply] = useState<SearchJob | null>(null)
   const fetchJobsRef = useRef<(pageNum: number) => Promise<void>>(async () => {})
 
   const { options: locationOptions, loading: locationSuggestLoading } = useGeocodeSuggest(
@@ -332,22 +339,61 @@ export default function JobSearchPage() {
                         </Typography>
                       </Box>
                       <Box sx={{ display: "flex", alignItems: "flex-start" }}>
-                        {job.applicationLink && (
-                          <Button
-                            component="a"
-                            href={job.applicationLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            variant="contained"
-                            size="small"
-                            startIcon={<LaunchIcon />}
-                            sx={{
-                              background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
-                              fontWeight: 600,
-                            }}
-                          >
-                            Apply
-                          </Button>
+                        {(job.applicationForm?.status === "published" || job.applicationLink) && (
+                          <Stack spacing={1} sx={{ minWidth: { xs: "100%", sm: 200 }, maxWidth: 280 }}>
+                            {job.applicationForm?.status === "published" && job.applicationLink && (
+                              <Typography variant="caption" color="text.secondary">
+                                This role has two application options—choose the one you prefer.
+                              </Typography>
+                            )}
+                            {job.applicationForm?.status === "published" && (
+                              <Button
+                                type="button"
+                                variant="contained"
+                                size="small"
+                                startIcon={<AssignmentIcon />}
+                                title="Submit using this career fair's built-in application form (you stay on this site)."
+                                onClick={() => {
+                                  setJobForApply(job)
+                                  setApplyDialogOpen(true)
+                                }}
+                                sx={{
+                                  width: "100%",
+                                  background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+                                  fontWeight: 600,
+                                }}
+                              >
+                                Apply on this site
+                              </Button>
+                            )}
+                            {job.applicationLink && (
+                              <Button
+                                component="a"
+                                href={job.applicationLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant={job.applicationForm?.status === "published" ? "outlined" : "contained"}
+                                size="small"
+                                startIcon={<LaunchIcon />}
+                                title="Opens the employer's own application page in a new browser tab."
+                                sx={{
+                                  width: "100%",
+                                  fontWeight: 600,
+                                  ...(job.applicationForm?.status === "published"
+                                    ? {
+                                        borderColor: "#388560",
+                                        color: "#388560",
+                                        "&:hover": { borderColor: "#2d6b4d", bgcolor: "rgba(56, 133, 96, 0.06)" },
+                                      }
+                                    : {
+                                        background: "linear-gradient(135deg, #388560 0%, #2d6b4d 100%)",
+                                      }),
+                                }}
+                              >
+                                Apply on company site
+                              </Button>
+                            )}
+                          </Stack>
                         )}
                       </Box>
                     </Box>
@@ -372,6 +418,18 @@ export default function JobSearchPage() {
           </>
         )}
       </Container>
+
+      {jobForApply && (
+        <JobApplicationFormDialog
+          open={applyDialogOpen}
+          onClose={() => {
+            setApplyDialogOpen(false)
+            setJobForApply(null)
+          }}
+          job={jobForApply}
+          studentId={auth.currentUser?.uid ?? null}
+        />
+      )}
     </BaseLayout>
   )
 }

--- a/frontend/src/pages/ShortlistPage.tsx
+++ b/frontend/src/pages/ShortlistPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { Container, Box, Typography } from '@mui/material';
+import { Container, Box, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import BaseLayout from '../components/BaseLayout';
 import { ShortlistManager, ScheduleCallDialog } from '../components/videoChat';
+import StudentProfileCard from '../components/StudentProfileCard';
 
 export default function ShortlistPage() {
   const [scheduleCallDialogOpen, setScheduleCallDialogOpen] = useState(false);
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null);
+  const [profileStudentId, setProfileStudentId] = useState<string | null>(null);
 
   const handleScheduleCall = (studentId: string) => {
     setSelectedStudentId(studentId);
@@ -29,7 +31,10 @@ export default function ShortlistPage() {
           </Typography>
         </Box>
 
-        <ShortlistManager onScheduleCall={handleScheduleCall} />
+        <ShortlistManager
+          onScheduleCall={handleScheduleCall}
+          onViewStudent={(studentId) => setProfileStudentId(studentId)}
+        />
 
         {selectedStudentId && (
           <ScheduleCallDialog
@@ -38,6 +43,29 @@ export default function ShortlistPage() {
             studentId={selectedStudentId}
           />
         )}
+
+        <Dialog
+          open={profileStudentId !== null}
+          onClose={() => setProfileStudentId(null)}
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle sx={{ bgcolor: 'rgba(56, 133, 96, 0.1)', fontWeight: 'bold' }}>
+            Student Profile
+          </DialogTitle>
+          <DialogContent sx={{ pt: 3 }}>
+            {profileStudentId ? (
+              <StudentProfileCard
+                studentId={profileStudentId}
+                enableEmployerMessaging
+                onBeforeNavigateToChat={() => setProfileStudentId(null)}
+              />
+            ) : null}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setProfileStudentId(null)}>Close</Button>
+          </DialogActions>
+        </Dialog>
       </Container>
     </BaseLayout>
   );

--- a/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -8,7 +8,24 @@ import ChatPage from "../ChatPage";
 import * as authUtils from "../../utils/auth";
 
 const mockNavigate = vi.fn();
-let mockLocationState: { state: { repId?: string } | null } = { state: null };
+
+/** Partial location; ChatPage reads `state`, `pathname`, and `search`. */
+const mockLocationState = {
+  pathname: "/",
+  search: "",
+  hash: "",
+  key: "test",
+  state: null as { repId?: string; dmStudentId?: string } | null,
+};
+
+const chatDmMock = vi.hoisted(() => ({
+  getOrCreateDirectChannel: vi.fn(),
+}));
+
+vi.mock("../../utils/chat", () => ({
+  getOrCreateDirectChannel: (uid: string, sid: string) =>
+    chatDmMock.getOrCreateDirectChannel(uid, sid),
+}));
 
 // Define mocks before using them
 const mockChannel = {
@@ -128,7 +145,12 @@ describe("ChatPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockNavigate.mockClear();
-    mockLocationState = { state: null };
+    mockLocationState.pathname = "/";
+    mockLocationState.search = "";
+    mockLocationState.state = null;
+
+    chatDmMock.getOrCreateDirectChannel.mockReset();
+    chatDmMock.getOrCreateDirectChannel.mockResolvedValue(mockChannel);
 
     // Reset mock channel
     mockChannel.watch.mockClear();
@@ -743,7 +765,7 @@ describe("ChatPage", () => {
   describe("Auto-DM from Booth", () => {
     it("creates DM channel when repId is provided in location state", async () => {
       mockStreamClient.userID = "user-1";
-      mockLocationState = { state: { repId: "rep-123" } };
+      mockLocationState.state = { repId: "rep-123" };
 
       renderChatPage();
 
@@ -757,7 +779,7 @@ describe("ChatPage", () => {
 
     it("does not create DM when no repId is provided", async () => {
       mockStreamClient.userID = "user-1";
-      mockLocationState = { state: null };
+      mockLocationState.state = null;
 
       renderChatPage();
 
@@ -775,7 +797,7 @@ describe("ChatPage", () => {
     it("handles error when auto-DM creation fails", async () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       mockStreamClient.userID = "user-1";
-      mockLocationState = { state: { repId: "rep-123" } };
+      mockLocationState.state = { repId: "rep-123" };
       
       // Make channel.watch fail
       mockChannel.watch.mockRejectedValueOnce(new Error("Failed to create channel"));
@@ -785,6 +807,67 @@ describe("ChatPage", () => {
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "CHAT: auto-DM failed",
+          expect.any(Error)
+        );
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("Student DM from profile / shortlist", () => {
+    it("opens DM via getOrCreateDirectChannel when dmStudentId is in location state", async () => {
+      mockStreamClient.userID = "user-1";
+      mockLocationState.state = { dmStudentId: "student-99" };
+
+      renderChatPage();
+
+      await waitFor(() => {
+        expect(chatDmMock.getOrCreateDirectChannel).toHaveBeenCalledWith("user-1", "student-99");
+        expect(mockNavigate).toHaveBeenCalledWith("/", {
+          replace: true,
+          state: {},
+        });
+      });
+    });
+
+    it("does not call getOrCreateDirectChannel when dmStudentId is absent", async () => {
+      mockStreamClient.userID = "user-1";
+      mockLocationState.state = null;
+
+      renderChatPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
+      });
+
+      expect(chatDmMock.getOrCreateDirectChannel).not.toHaveBeenCalled();
+    });
+
+    it("skips student DM when dmStudentId matches current user", async () => {
+      mockStreamClient.userID = "user-1";
+      mockLocationState.state = { dmStudentId: "user-1" };
+
+      renderChatPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("base-layout")).toBeInTheDocument();
+      });
+
+      expect(chatDmMock.getOrCreateDirectChannel).not.toHaveBeenCalled();
+    });
+
+    it("logs when open student DM fails", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockStreamClient.userID = "user-1";
+      mockLocationState.state = { dmStudentId: "student-99" };
+      chatDmMock.getOrCreateDirectChannel.mockRejectedValueOnce(new Error("dm failed"));
+
+      renderChatPage();
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "CHAT: open student DM failed",
           expect.any(Error)
         );
       });

--- a/frontend/src/pages/__tests__/Company.test.tsx
+++ b/frontend/src/pages/__tests__/Company.test.tsx
@@ -1904,6 +1904,18 @@ describe("Company", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/company/company-1/booth/b1");
     });
 
+    it("navigates to booth visitor analytics when Visitor analytics is clicked", async () => {
+      const user = userEvent.setup();
+      setBoothListFetch([{ id: "b1", boothName: "Alpha" }]);
+      renderComp();
+
+      await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+      const alphaRow = screen.getByText("Alpha").closest("div")!.parentElement!;
+      await user.click(within(alphaRow).getByRole("button", { name: /visitor analytics/i }));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/booth/b1/visitors");
+    });
+
     it("navigates to create booth when 'Create New Booth' is clicked", async () => {
       const user = userEvent.setup();
       setBoothListFetch([]);

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -166,7 +166,7 @@ describe("Dashboard", () => {
       })
     })
 
-    it("displays Browse Company Booths card for students", async () => {
+    it("displays Booth History card for students", async () => {
       mockGetCurrentUser.mockReturnValue({
         uid: "u1",
         email: "student@test.com",
@@ -180,14 +180,15 @@ describe("Dashboard", () => {
       )
 
       await waitFor(() => {
-        expect(screen.getByText("Browse Company Booths")).toBeInTheDocument()
+        expect(screen.getByRole("button", { name: /view booth history/i })).toBeInTheDocument()
       })
 
-      const viewBoothsButton = screen.getByRole("button", { name: /browse all fairs/i })
-      expect(viewBoothsButton).toBeEnabled()
+      const historyButton = screen.getByRole("button", { name: /view booth history/i })
+      expect(historyButton).toBeEnabled()
     })
 
-    it("navigates to booths page when button clicked (when fair is live)", async () => {
+    it("navigates to booth history when student clicks View Booth History", async () => {
+      const user = userEvent.setup()
       mockGetCurrentUser.mockReturnValue({
         uid: "u1",
         email: "student@test.com",
@@ -204,8 +205,8 @@ describe("Dashboard", () => {
         expect(screen.getByText(/Career Opportunities/)).toBeInTheDocument()
       })
 
-      // Note: button is disabled when fair not live, so this just verifies it exists
-      expect(screen.getByRole("button", { name: /browse all fairs/i })).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: /view booth history/i }))
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard/booth-history")
     })
 
     it("does not fetch job invitations when getIdToken returns null", async () => {
@@ -540,7 +541,7 @@ describe("Dashboard", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/companies")
     })
 
-    it("displays Browse All Booths card with disabled state when fair not live", async () => {
+    it("does not show View Booths or Booth History on company owner dashboard", async () => {
       mockGetCurrentUser.mockReturnValue({
         uid: "u2",
         email: "owner@test.com",
@@ -554,43 +555,11 @@ describe("Dashboard", () => {
       )
 
       await waitFor(() => {
-        const viewBoothsButtons = screen.getAllByRole("button", { name: /view booths/i })
-        expect(viewBoothsButtons[0]).toBeDisabled()
-      })
-    })
-
-    it("navigates to booth history when Booth History clicked (company owner)", async () => {
-      const user = userEvent.setup()
-      mockGetCurrentUser.mockReturnValue({
-        uid: "u2",
-        email: "owner@test.com",
-        role: "companyOwner",
-      })
-      vi.mocked(globalThis.fetch).mockImplementation((input: string | Request | URL) => {
-        const url = getFetchUrl(input)
-        if (url.includes("/api/fairs")) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ fairs: [{ isLive: true }] }),
-          }) as Promise<Response>
-        }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) }) as Promise<Response>
+        expect(screen.getByText("Team Members")).toBeInTheDocument()
       })
 
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      )
-
-      await waitFor(() => {
-        const boothHistoryBtn = screen.getByRole("button", { name: /booth history/i })
-        expect(boothHistoryBtn).toBeInTheDocument()
-        expect(boothHistoryBtn).toBeEnabled()
-      })
-
-      await user.click(screen.getByRole("button", { name: /booth history/i }))
-      expect(mockNavigate).toHaveBeenCalledWith("/dashboard/booth-history")
+      expect(screen.queryByRole("button", { name: /view booths/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: /booth history/i })).not.toBeInTheDocument()
     })
 
     it("displays enrolled fairs count for company owner", async () => {

--- a/frontend/src/pages/__tests__/JobSearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/JobSearchPage.test.tsx
@@ -20,9 +20,20 @@ vi.mock("../../utils/auth", () => ({
 vi.mock("../../firebase", () => ({
   auth: {
     currentUser: {
+      uid: "student-test-uid",
       getIdToken: vi.fn().mockResolvedValue("mock-token"),
     },
   },
+}))
+
+vi.mock("../../components/JobApplicationFormDialog", () => ({
+  default: ({
+    open,
+    job,
+  }: {
+    open: boolean
+    job: { id: string; name: string }
+  }) => (open ? <div data-testid="job-apply-dialog">{job.id}:{job.name}</div> : null),
 }))
 
 vi.mock("../../components/BaseLayout", () => ({
@@ -199,7 +210,7 @@ describe("JobSearchPage", () => {
     })
   })
 
-  it("renders Apply link when applicationLink is present", async () => {
+  it("renders external apply link when applicationLink is present", async () => {
     ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => defaultListResponse,
@@ -207,16 +218,16 @@ describe("JobSearchPage", () => {
 
     renderPage()
 
-    const apply = await screen.findByRole("link", { name: /apply/i })
+    const apply = await screen.findByRole("link", { name: /apply on company site/i })
     expect(apply).toHaveAttribute("href", "https://example.com/apply")
   })
 
-  it("does not render Apply when applicationLink is null", async () => {
+  it("does not render apply actions when there is no link and no published form", async () => {
     ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({
         ...defaultListResponse,
-        jobs: [{ ...defaultListResponse.jobs[0], applicationLink: null }],
+        jobs: [{ ...defaultListResponse.jobs[0], applicationLink: null, applicationForm: null }],
       }),
     })
 
@@ -226,7 +237,51 @@ describe("JobSearchPage", () => {
       expect(screen.getByText("Software Engineer")).toBeInTheDocument()
     })
 
-    expect(screen.queryByRole("link", { name: /apply/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /apply on company site/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /apply on this site/i })).not.toBeInTheDocument()
+  })
+
+  it("renders internal apply and opens dialog when published applicationForm exists", async () => {
+    const user = userEvent.setup()
+    const publishedForm = {
+      title: "Application",
+      status: "published" as const,
+      fields: [{ id: "email", type: "shortText" as const, label: "Email", required: true }],
+    }
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...defaultListResponse,
+        jobs: [{ ...defaultListResponse.jobs[0], applicationLink: null, applicationForm: publishedForm }],
+      }),
+    })
+
+    renderPage()
+
+    await user.click(await screen.findByRole("button", { name: /apply on this site/i }))
+    expect(await screen.findByTestId("job-apply-dialog")).toHaveTextContent("j1:Software Engineer")
+  })
+
+  it("shows both apply options when link and published form exist", async () => {
+    const publishedForm = {
+      title: "Application",
+      status: "published" as const,
+      fields: [{ id: "email", type: "shortText" as const, label: "Email", required: true }],
+    }
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...defaultListResponse,
+        jobs: [{ ...defaultListResponse.jobs[0], applicationForm: publishedForm }],
+      }),
+    })
+
+    renderPage()
+
+    expect(await screen.findByText(/two application options/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /apply on this site/i })).toBeInTheDocument()
+    const external = screen.getByRole("link", { name: /apply on company site/i })
+    expect(external).toHaveAttribute("href", "https://example.com/apply")
   })
 
   it("truncates long descriptions", async () => {

--- a/frontend/src/pages/__tests__/ShortlistPage.test.tsx
+++ b/frontend/src/pages/__tests__/ShortlistPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ShortlistPage from "../ShortlistPage";
 
@@ -7,11 +7,30 @@ vi.mock("../../components/BaseLayout", () => ({
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="base-layout">{children}</div>,
 }));
 
+vi.mock("../../components/StudentProfileCard", () => ({
+  default: ({ studentId }: { studentId: string }) => (
+    <div data-testid="student-profile-card">{studentId}</div>
+  ),
+}));
+
 vi.mock("../../components/videoChat", () => ({
-  ShortlistManager: ({ onScheduleCall }: { onScheduleCall: (studentId: string) => void }) => (
-    <button type="button" onClick={() => onScheduleCall("student-99")}>
-      Schedule from shortlist
-    </button>
+  ShortlistManager: ({
+    onScheduleCall,
+    onViewStudent,
+  }: {
+    onScheduleCall: (studentId: string) => void;
+    onViewStudent?: (studentId: string) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onScheduleCall("student-99")}>
+        Schedule from shortlist
+      </button>
+      {onViewStudent ? (
+        <button type="button" onClick={() => onViewStudent("student-88")}>
+          View shortlist student
+        </button>
+      ) : null}
+    </div>
   ),
   ScheduleCallDialog: ({
     open,
@@ -46,6 +65,7 @@ describe("ShortlistPage", () => {
       screen.getByText(/Manage your candidate shortlist and schedule 1v1 video calls with interested students/i)
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Schedule from shortlist/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /View shortlist student/i })).toBeInTheDocument();
   });
 
   it("opens ScheduleCallDialog with student id when shortlist schedules a call", async () => {
@@ -70,5 +90,32 @@ describe("ShortlistPage", () => {
     await user.click(screen.getByRole("button", { name: /Close schedule dialog/i }));
 
     expect(screen.queryByTestId("schedule-dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens student profile dialog when shortlist requests view", async () => {
+    const user = userEvent.setup();
+    render(<ShortlistPage />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /View shortlist student/i }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Student Profile")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("student-profile-card")).toHaveTextContent("student-88");
+  });
+
+  it("closes profile dialog via Close action", async () => {
+    const user = userEvent.setup();
+    render(<ShortlistPage />);
+
+    await user.click(screen.getByRole("button", { name: /View shortlist student/i }));
+    await screen.findByTestId("student-profile-card");
+
+    await user.click(screen.getByRole("button", { name: /^Close$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("student-profile-card")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/utils/__tests__/chat.test.ts
+++ b/frontend/src/utils/__tests__/chat.test.ts
@@ -41,7 +41,7 @@ describe("getOrCreateDirectChannel", () => {
 
     const result = await getOrCreateDirectChannel("user1", "user2")
 
-    expect(mockChannel).toHaveBeenCalledWith("messaging", "dm_user1_user2", {
+    expect(mockChannel).toHaveBeenCalledWith("messaging", "dm-user1-user2", {
       members: ["user1", "user2"],
     })
     expect(mockCreate).toHaveBeenCalled()

--- a/frontend/src/utils/chat.ts
+++ b/frontend/src/utils/chat.ts
@@ -1,28 +1,29 @@
 import { streamClient } from "./streamClient";
 
-export async function getOrCreateDirectChannel(
-  currentUserId: string,
-  repUserId: string
-) {
+/**
+ * Open or create a 1:1 messaging channel between two users.
+ * Uses a stable channel id (sorted member ids) so it matches NewChatDialog and avoids duplicates.
+ */
+export async function getOrCreateDirectChannel(currentUserId: string, otherUserId: string) {
   if (!streamClient) throw new Error("Stream client not initialized.");
 
-  // Look for an existing 1-on-1 messaging channel between these two users
-  const result = await streamClient.queryChannels({
-    type: "messaging",
-    member_count: 2,
-    members: { $in: [currentUserId, repUserId] },
-  });
+  const sorted = [currentUserId, otherUserId].sort((a, b) => a.localeCompare(b));
+  const channelId = `dm-${sorted[0]}-${sorted[1]}`;
 
-  if (result.length > 0) {
-    const existing = result[0];
-    await existing.watch();
-    return existing;
+  const existing = await streamClient.queryChannels(
+    { type: "messaging", cid: `messaging:${channelId}` },
+    {},
+    { limit: 1 }
+  );
+
+  if (existing.length > 0) {
+    const ch = existing[0];
+    await ch.watch();
+    return ch;
   }
 
-  // No existing channel → create a new one
-  const channelId = `dm_${currentUserId}_${repUserId}`;
   const channel = streamClient.channel("messaging", channelId, {
-    members: [currentUserId, repUserId],
+    members: sorted,
   });
 
   await channel.create();


### PR DESCRIPTION
Use this as your PR description (adjust the title if yours differs):

---

## Summary

This PR adds **employer → student messaging** from the **student profile card** (used in booth visitor analytics and on the candidate shortlist), reuses the **same `StudentProfileCard`** in both places, and **deep-links into chat** so Stream opens or creates a **stable 1:1 channel** with the student. It also includes **test coverage and test fixes** for the new flows.

## What changed

### Product / UX

- **Candidate shortlist**: Clicking a shortlisted student opens the same **Student Profile** dialog as “View profile” on booth visitor analytics, with optional notes/email context unchanged for other actions.
- **Student profile card**: Optional **`enableEmployerMessaging`** shows an **“Open messages”** action when the signed-in user is not the profile’s student; it navigates to **`/dashboard/chat`** with **`state: { dmStudentId }`**. **`onBeforeNavigateToChat`** runs first so parent dialogs can close before navigation.
- **Chat page**: When **`dmStudentId`** is present in location state (after Stream is ready), the app calls **`getOrCreateDirectChannel`** to reuse or create the DM, sets it as the active channel, then **replaces** the current history entry with **cleared state** so refresh does not reopen the DM flow.

### Technical

- **`getOrCreateDirectChannel`**: Uses a **deterministic channel id** and **sorted member ids** so both sides resolve the same channel and existing channels are found reliably (aligned with the rest of the chat stack).
- **Booth visitors page**: Profile dialog passes **`enableEmployerMessaging`** (and closes via **`onBeforeNavigateToChat`** where applicable).
- **Shortlist**: **`ShortlistManager`** accepts **`onViewStudent`**; row **`ListItemButton`** opens the profile; schedule/delete use **`stopPropagation`** so they do not trigger “view profile”.
- **Tests**: **`ChatPage`**, **`StudentProfileCard`**, **`ShortlistPage`**, **`ShortlistManager`**, and **`chat`** unit tests updated or added; **`useLocation`** mock in **`ChatPage`** tests now includes **`pathname`** / **`search`** so navigation assertions match real behavior.

*(If your PR also includes unrelated items from the same branch—e.g. booth 403 / company auth, job apply buttons, dashboard layout—add a short bullet list under “Also in this branch” so reviewers can scope their review.)*

## How to test (for reviewers)

### Prerequisites

- Frontend env with **Stream** configured (**`VITE_STREAM_API_KEY`** and a working **`/api/stream-token`** flow).
- Two accounts: **employer/rep** (company) and **student**; student should appear on the shortlist and/or in **booth visitor analytics** after visiting a booth.

### Shortlist → profile → messages

1. Sign in as the **employer** and open **Candidate shortlist** (or the route your app uses for the shortlist page).
2. Click a **row** (name/email area), not only the calendar or delete icons.
3. Confirm the **Student Profile** dialog matches what you see from **Booth visitors → View profile** for the same student (layout, fields, resume/LinkedIn behavior as before).
4. Click **Open messages**.
5. Confirm you land on **`/dashboard/chat`**, the **DM with that student** is selected (or created if it did not exist), and you can send a test message.
6. Use browser **back** or open the shortlist again and repeat **Open messages**; confirm it **reuses** the same conversation rather than creating duplicates (same stable channel).

### Booth visitors → profile → messages

1. As employer, open **booth visitor analytics** (or equivalent) where **View profile** exists.
2. Open **View profile** for a student; confirm **Open messages** appears when appropriate (not when viewing your own profile as that student).
3. Click **Open messages** and confirm the same chat behavior as above.

### Regression checks

- **Schedule call** / **remove from shortlist** from the shortlist row still work and **do not** open the profile when clicking those icons only.
- **Rep booth → chat** flow with **`repId`** in location state (if you use it) still auto-opens that DM; **`dmStudentId`** should not interfere when absent.
- Run **`npm test`** / **`npx vitest run`** in **`frontend`** and confirm all tests pass (especially **`ChatPage`**, **`StudentProfileCard`**, **`ShortlistPage`**, **`ShortlistManager`**, **`chat.test`**).

---
