### PR TITLE
fix(jekyll): escape Liquid syntax in superpowers plan docs

### DIFF
--- a/docs/superpowers/plans/2026-04-15-ghost-mode.md
+++ b/docs/superpowers/plans/2026-04-15-ghost-mode.md
@@ -360,6 +360,7 @@ const handleToggleGhostMode = async (e: React.ChangeEvent<HTMLInputElement>) => 
 
 In the Attendees tab panel (inside `{activeTab === 1 && ...}` around line 373), add the toggle just inside the `<Container>` and before the loading/empty checks:
 
+{% raw %}
 ```tsx
 <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
   <FormControlLabel
@@ -374,6 +375,7 @@ In the Attendees tab panel (inside `{activeTab === 1 && ...}` around line 373), 
   />
 </Box>
 ```
+{% endraw %}
 
 - [ ] **Step 7: Run tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-04-17-multi-booth.md
+++ b/docs/superpowers/plans/2026-04-17-multi-booth.md
@@ -766,6 +766,7 @@ In `frontend/src/App.tsx`, add a new route after the existing `/company/:company
 
 In `frontend/src/pages/Company.tsx`, replace the `BoothManagementCard` component (lines 309-378) with:
 
+{% raw %}
 ```tsx
 function BoothManagementCard({ companyId, navigate }: Readonly<{
   companyId: string
@@ -864,6 +865,7 @@ function BoothManagementCard({ companyId, navigate }: Readonly<{
   )
 }
 ```
+{% endraw %}
 
 - [ ] **Step 3: Update the `BoothManagementCard` call site**
 
@@ -1063,6 +1065,7 @@ useEffect(() => {
 
 In the join dialog JSX (look for the `Dialog` that contains the invite code input), add a booth selection section after the invite code field but before the submit button. Use MUI `FormGroup` with `Checkbox` items:
 
+{% raw %}
 ```tsx
 {companyBooths.length > 0 && (
   <Box sx={{ mt: 2 }}>
@@ -1097,6 +1100,7 @@ In the join dialog JSX (look for the `Dialog` that contains the invite code inpu
   </Typography>
 )}
 ```
+{% endraw %}
 
 Add the necessary MUI imports: `FormGroup`, `Checkbox`, `FormControlLabel` (if not already imported).
 

--- a/docs/superpowers/plans/2026-05-05-add-company-name-search.md
+++ b/docs/superpowers/plans/2026-05-05-add-company-name-search.md
@@ -450,6 +450,7 @@ Expected: multiple FAIL — "combobox" not found, "Re-enroll" not found, etc.
 
 Find the `{/* Add Company Dialog */}` block (around line 999–1021) and replace it entirely:
 
+{% raw %}
 ```tsx
       {/* Add Company Dialog */}
       <Dialog open={addDialogOpen} onClose={() => {
@@ -511,6 +512,7 @@ Find the `{/* Add Company Dialog */}` block (around line 999–1021) and replace
         </DialogActions>
       </Dialog>
 ```
+{% endraw %}
 
 - [ ] **Step 4: Run tests to verify they pass**
 


### PR DESCRIPTION
Jekyll processes {{ }} as Liquid variable tags, causing a build error when encountering JSX/MUI sx prop object notation in code examples. Wrapping affected tsx code blocks with {% raw %}...{% endraw %} in the ghost-mode, multi-booth, and add-company-name-search plan files.